### PR TITLE
Feature/22445

### DIFF
--- a/src/Middleware/RbacMiddleware.php
+++ b/src/Middleware/RbacMiddleware.php
@@ -139,11 +139,13 @@ class RbacMiddleware
         $userData = [];
         if ($user) {
             $userData = Hash::get($user, 'User', []);
+            $userData = is_object($userData) ? $userData->toArray() : $userData;
         }
 
         if (!$this->rbac->checkPermissions($userData, $request)) {
             $response = $this->notAuthorized($userData, $request, $response);
         }
+        $request = $request->withAttribute('rbac', $this->rbac);
 
         return $next($request, $response);
     }


### PR DESCRIPTION
Also setting rbac instance into request object to be used after when needed, eg: creating links