### PR TITLE
Update ApiKeyAuthenticate.md

### DIFF
--- a/Docs/Documentation/ApiKeyAuthenticate.md
+++ b/Docs/Documentation/ApiKeyAuthenticate.md
@@ -7,9 +7,10 @@ Setup
 ApiKeyAuthenticate default configuration is
 ```php
     protected $_defaultConfig = [
-        //type, can be either querystring or header
+        //type, can be either querystring or header.
         'type' => self::TYPE_QUERYSTRING,
-        //name to retrieve the api key value from
+        //name to retrieve the api key value from.
+        // If using headers, underscores (_) may not be allowed by your server configuration
         'name' => 'api_key',
         //db field where the key is stored
         'field' => 'api_token',


### PR DESCRIPTION
Updating the documentation for ApiKeyAuthenticate to detail about how underscores in headers are dropped by Ngnix and Apache 2.4.x

Ngnix https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/?highlight=disappearing%20http%20headers#missing-disappearing-http-headers
`
If you do not explicitly set underscores_in_headers on;, NGINX will silently drop HTTP headers with underscores (which are perfectly valid according to the HTTP standard). This is done in order to prevent ambiguities when mapping headers to CGI variables as both dashes and underscores are mapped to underscores during that process.
`

Apache https://httpd.apache.org/docs/trunk/new_features_2_4.html
`
Translation of headers to environment variables is more strict than before to mitigate some possible cross-site-scripting attacks via header injection. Headers containing invalid characters (including underscores) are now silently dropped. Environment Variables in Apache has some pointers on how to work around broken legacy clients which require such headers. (This affects all modules which use these environment variables.)`