### PR TITLE
 Exclude more files from being exported

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Remove files for archives generated using `git archive`
+.travis.yml export-ignore
+.gitattributes export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
I was toying around with a deployment script and noticed these unnecessary (in a deployment context) files.