### PR TITLE
Add option to use array for autoloading permissions

### DIFF
--- a/src/Rbac/Permissions/ConfigProvider.php
+++ b/src/Rbac/Permissions/ConfigProvider.php
@@ -36,7 +36,19 @@ class ConfigProvider extends AbstractProvider
     public function getPermissions()
     {
         $autoload = $this->getConfig('autoload_config');
+
         if ($autoload) {
+            if (is_array($autoload)) {
+                $permissions = [];
+
+                foreach ($autoload as $configItem) {
+                    $permissions = array_merge($permissions, $this->_loadPermissions($configItem));
+
+                }
+
+                return $permissions;
+            }
+
             return $this->_loadPermissions($autoload);
         }
 


### PR DESCRIPTION
Example usage in `users.php` in the Users plugin:

```php
'Auth' => [
	'RbacPolicy' => [
		'adapter' => [
			'autoload_config' => [
				'MyPlugin.permissions',
				'MyOtherPlugin.permissions',
				'permissions',
			],
		],
	],
],
```

Since the array is optional, it should not break existing implementations