### PR TITLE
Issue/69 fix zend diactoros uri

### DIFF
--- a/src/Authentication/AuthenticationService.php
+++ b/src/Authentication/AuthenticationService.php
@@ -60,6 +60,7 @@ class AuthenticationService extends BaseService
 
         return $this->_result = $result;
     }
+
     /**
      * Proceed to webauthn2fa flow after a valid result result
      *

--- a/src/Rbac/Rules/AbstractRule.php
+++ b/src/Rbac/Rules/AbstractRule.php
@@ -81,7 +81,7 @@ abstract class AbstractRule implements Rule
         $controller = $params['controller'] ?? null;
         $modelClass = ($plugin ? $plugin . '.' : '') . $controller;
 
-        $this->modelFactory('Table', function (string $alias, array $options) : \Cake\ORM\Table {
+        $this->modelFactory('Table', function (string $alias, array $options): \Cake\ORM\Table {
             return $this->getTableLocator()->get($alias, $options);
         });
         if (empty($modelClass)) {

--- a/src/Rbac/Rules/Owner.php
+++ b/src/Rbac/Rules/Owner.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
  */
 namespace CakeDC\Auth\Rbac\Rules;
 
-use Cake\Core\Exception\CakeException;
 use Cake\Utility\Hash;
 use OutOfBoundsException;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/Traits/IsAuthorizedTrait.php
+++ b/src/Traits/IsAuthorizedTrait.php
@@ -16,7 +16,7 @@ namespace CakeDC\Auth\Traits;
 use Authorization\AuthorizationServiceInterface;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
-use Zend\Diactoros\Uri;
+use Laminas\Diactoros\Uri;
 
 trait IsAuthorizedTrait
 {

--- a/tests/TestCase/Authentication/AuthenticationServiceTest.php
+++ b/tests/TestCase/Authentication/AuthenticationServiceTest.php
@@ -263,6 +263,7 @@ class AuthenticationServiceTest extends TestCase
         $actual = $service->getFailures();
         $this->assertEquals($expected, $actual);
     }
+
     /**
      * testAuthenticate
      *

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -56,7 +56,7 @@ class CookieAuthenticatorTest extends TestCase
         $identifiers = new IdentifierCollection([
             'Authentication.Password',
         ]);
-        $uri = new \Zend\Diactoros\Uri('/login');
+        $uri = new \Laminas\Diactoros\Uri('/login');
         $uri->base = null;
         $request = new \Cake\Http\ServerRequest();
         $request = $request->withUri($uri);

--- a/tests/TestCase/Authenticator/SocialAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SocialAuthenticatorTest.php
@@ -20,8 +20,8 @@ use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Authenticator\SocialAuthenticator;
 use CakeDC\Auth\Social\Service\ServiceFactory;
+use Laminas\Diactoros\Uri;
 use League\OAuth2\Client\Provider\FacebookUser;
-use Zend\Diactoros\Uri;
 
 /**
  * Test Case for SocialAuthenticator class

--- a/tests/TestCase/Authenticator/TwoFactorAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TwoFactorAuthenticatorTest.php
@@ -27,7 +27,7 @@ class TwoFactorAuthenticatorTest extends TestCase
      */
     public function testAuthenticateFailedNoData()
     {
-        $uri = new \Zend\Diactoros\Uri('/testpath');
+        $uri = new \Laminas\Diactoros\Uri('/testpath');
         $uri->base = null;
         $request = new \Cake\Http\ServerRequest();
         $request = $request->withUri($uri);
@@ -51,7 +51,7 @@ class TwoFactorAuthenticatorTest extends TestCase
      */
     public function testAuthenticateFailedInvalidUrl()
     {
-        $uri = new \Zend\Diactoros\Uri('/testpath');
+        $uri = new \Laminas\Diactoros\Uri('/testpath');
         $uri->base = null;
         $request = new \Cake\Http\ServerRequest();
         $request = $request->withUri($uri);
@@ -82,7 +82,7 @@ class TwoFactorAuthenticatorTest extends TestCase
      */
     public function testAuthenticate()
     {
-        $uri = new \Zend\Diactoros\Uri('/testpath');
+        $uri = new \Laminas\Diactoros\Uri('/testpath');
         $uri->base = null;
         $request = new \Cake\Http\ServerRequest();
         $request = $request->withUri($uri);

--- a/tests/TestCase/Middleware/SocialAuthMiddlewareTest.php
+++ b/tests/TestCase/Middleware/SocialAuthMiddlewareTest.php
@@ -20,9 +20,9 @@ use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Middleware\SocialAuthMiddleware;
 use CakeDC\Auth\Social\Service\OAuth2Service;
+use Laminas\Diactoros\Uri;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Diactoros\Uri;
 
 class SocialAuthMiddlewareTest extends TestCase
 {

--- a/tests/TestCase/Social/MapUserTest.php
+++ b/tests/TestCase/Social/MapUserTest.php
@@ -27,6 +27,7 @@ class MapUserTest extends TestCase
      * @var \\League\OAuth2\Client\Provider\Facebook&\PHPUnit\Framework\MockObject\MockObject|mixed
      */
     public $Provider;
+
     /**
      * Setup the test case, backup the static object values so they can be restored.
      * Specifically backs up the contents of Configure and paths in App if they have

--- a/tests/TestCase/Social/Service/OAuth1ServiceTest.php
+++ b/tests/TestCase/Social/Service/OAuth1ServiceTest.php
@@ -20,10 +20,10 @@ use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Social\Service\OAuth1Service;
 use CakeDC\Auth\Social\Service\ServiceInterface;
+use Laminas\Diactoros\Uri;
 use League\OAuth1\Client\Credentials\TemporaryCredentials;
 use League\OAuth1\Client\Credentials\TokenCredentials;
 use League\OAuth1\Client\Server\User;
-use Zend\Diactoros\Uri;
 
 class OAuth1ServiceTest extends TestCase
 {

--- a/tests/TestCase/Social/Service/OAuth2ServiceTest.php
+++ b/tests/TestCase/Social/Service/OAuth2ServiceTest.php
@@ -21,8 +21,8 @@ use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Social\Service\OAuth2Service;
 use CakeDC\Auth\Social\Service\ServiceInterface;
+use Laminas\Diactoros\Uri;
 use League\OAuth2\Client\Provider\FacebookUser;
-use Zend\Diactoros\Uri;
 
 class OAuth2ServiceTest extends TestCase
 {


### PR DESCRIPTION
Replace Zend\Diactoros\Uri imports by Laminas\Diactoros\Uri to fix the following issues : 

https://github.com/CakeDC/auth/issues/69
https://github.com/CakeDC/users/issues/997

Since CakePHP is using Laminas namespaces I don't see any drawbacks to use it as well in the plugin 

https://github.com/cakephp/cakephp/blob/4.x/composer.json#L31

Moreover the Zend Diactoros repository is abandoned since the end of 2019. 

This is my first contribution, let me know if I've made something wrong.