### PR TITLE
8.next: Cake5 compatiblity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,11 @@ jobs:
       matrix:
         php-version: ['8.1']
         db-type: [sqlite, pgsql]
-        prefer-lowest: ['']
         include:
           - php-version: '8.1'
             db-type: 'mariadb'
           - php-version: '8.1'
             db-type: 'mysql'
-            prefer-lowest: 'prefer-lowest'
 
     steps:
       - name: Setup MySQL latest
@@ -61,15 +59,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
+          key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}
 
       - name: Composer install
-        run: |
-          if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
-            composer update --prefer-lowest --prefer-stable
-          else
-            composer update
-          fi
+        run: composer update
+
 
       - name: Setup problem matchers for PHPUnit
         if: matrix.php-version == '8.1' && matrix.db-type == 'mysql'
@@ -124,7 +118,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
+          key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}
 
       - name: composer install
         run: composer stan-setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,37 +102,21 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
-          extensions: mbstring, intl, apcu, memcached, redis
-          tools: cs2pr
+          extensions: mbstring, intl
           coverage: none
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Get date part for cache key
-        id: key-date
-        run: echo "::set-output name=date::$(date +'%Y-%m')"
-
-      - name: Cache composer dependencies
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}
+          tools: cs2pr, vimeo/psalm:5.4, phpstan:1.9
 
       - name: composer install
-        run: composer stan-setup
+        run: ramsey/composer-install@v2
 
       - name: Run PHP CodeSniffer
-        run: composer cs-check
+        run: vendor/bin/phpcs --report=checkstyle src/ tests/ | cs2pr
         continue-on-error: true
 
       - name: Run psalm
-        if: success() || failure()
-        run: composer psalm
-        continue-on-error: true
+        if: always()
+        run: psalm --output-format=github
 
       - name: Run phpstan
-        if: success() || failure()
-        run: composer stan
-        continue-on-error: true
+        if: always()
+        run: phpstan analyse --error-format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   testsuite:
     runs-on: ubuntu-22.04
@@ -12,8 +15,14 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ['8.1']
-        db-type: [sqlite, mysql, pgsql]
+        db-type: [sqlite, pgsql]
         prefer-lowest: ['']
+        include:
+          - php-version: '8.1'
+            db-type: 'mariadb'
+          - php-version: '8.1'
+            db-type: 'mysql'
+            prefer-lowest: 'prefer-lowest'
 
     steps:
       - name: Setup MySQL latest
@@ -24,7 +33,13 @@ jobs:
         if: matrix.db-type == 'pgsql'
         run: docker run --rm --name=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=cakephp -p 5432:5432 -d postgres
 
-      - uses: actions/checkout@v2
+      - uses: getong/mariadb-action@v1.1
+        if: matrix.db-type == 'mariadb'
+        with:
+          mysql database: 'cakephp'
+          mysql root password: 'root'
+
+      - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -43,7 +58,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m')"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
@@ -57,22 +72,29 @@ jobs:
           fi
 
       - name: Setup problem matchers for PHPUnit
-        if: matrix.php-version == '7.4' && matrix.db-type == 'mysql'
+        if: matrix.php-version == '8.1' && matrix.db-type == 'mysql'
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Wait for MySQL
+        if: matrix.db-type == 'mysql' || matrix.db-type == 'mariadb'
+        run: while ! `mysqladmin ping -h 127.0.0.1 --silent`; do printf 'Waiting for MySQL...\n'; sleep 2; done;
 
       - name: Run PHPUnit
         run: |
           if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
           if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
+          if [[ ${{ matrix.db-type }} == 'mariadb' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
           if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
-          if [[ ${{ matrix.php-version }} == '7.4' ]]; then
-            export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
+          
+          if [[ ${{ matrix.php-version }} == '8.1' ]]; then
+            export CODECOVERAGE=1 
+            vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
           else
             vendor/bin/phpunit
           fi
 
       - name: Submit code coverage
-        if: matrix.php-version == '7.4'
+        if: matrix.php-version == '8.1'
         uses: codecov/codecov-action@v1
 
   cs-stan:
@@ -85,7 +107,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl, apcu, memcached, redis
           tools: cs2pr
           coverage: none

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.2.0",
-        "cakephp/cakephp": "^4.0"
+        "php": ">=8.1.0",
+        "cakephp/cakephp": "5.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^9.5",
         "league/oauth2-facebook": "@stable",
         "league/oauth2-instagram": "@stable",
         "league/oauth2-google": "@stable",
@@ -40,11 +40,10 @@
         "google/recaptcha": "@stable",
         "robthree/twofactorauth": "^1.6",
         "league/oauth1-client": "^1.7",
-        "cakephp/authorization": "^2.0",
-        "cakephp/cakephp-codesniffer": "^4.0",
-        "cakephp/authentication": "^2.0",
-        "yubico/u2flib-server": "^1.0",
-        "php-coveralls/php-coveralls": "^2.4"
+        "cakephp/authorization": "3.x-dev",
+        "cakephp/cakephp-codesniffer": "^5.0",
+        "cakephp/authentication": "3.x-dev",
+        "yubico/u2flib-server": "^1.0"
     },
     "suggest": {
     },
@@ -73,7 +72,11 @@
         "test": "phpunit --stderr",
         "stan": "phpstan analyse src/",
         "psalm": "php vendor/psalm/phar/psalm.phar --show-info=false src/ ",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:0.12.94 psalm/phar:~4.9.2 && mv composer.backup composer.json",
-        "coverage-test": "phpunit --stderr --coverage-clover=clover.xml"
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.9.0 psalm/phar:^5.1.0 && mv composer.backup composer.json"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -112,7 +112,7 @@ return [
         'enabled' => false,
         'appName' => null,//App must set a valid name here
         'id' => null,//default value is the current domain
-        'checker' => \CakeDC\Auth\Authentication\DefaultWebauthn2fAuthenticationChecker::class,
+        'checker' => \CakeDC\Auth\Authentication\DefaultWebauthn2FAuthenticationChecker::class,
         'startAction' => [
             'plugin' => 'CakeDC/Users',
             'controller' => 'Users',

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -9,16 +9,5 @@
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 use Cake\Core\Configure;
-use Cake\Routing\Router;
 
 Configure::load('CakeDC/Auth.auth');
-$oauthPath = Configure::read('OAuth.path');
-if (is_array($oauthPath)) {
-    Router::scope('/auth', function ($routes) use ($oauthPath) {
-        $routes->connect(
-            '/:provider',
-            $oauthPath,
-            ['provider' => implode('|', array_keys(Configure::read('OAuth.providers')))]
-        );
-    });
-}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,8 @@
 parameters:
     level: 6
-    autoload_files:
+    checkMissingIterableValueType: false
+    checkGenericClassInNonGenericObjectType: false
+    treatPhpDocTypesAsCertain: false
+    bootstrapFiles:
         - tests/bootstrap.php
-    ignoreErrors:
-        - '#Method CakeDC\\Auth\\Rbac\\Rules\\AbstractRule::_getTableFromRequest\(\) should return Cake\\ORM\\Table but returns Cake\\Datasource\\RepositoryInterface.#'
 services:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -44,11 +44,6 @@
             <directory>./tests/TestCase</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 
     <!-- Setup a listener for fixtures -->
     <extensions>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -33,13 +33,24 @@
     </filter>
 
     <!-- Setup a listener for fixtures -->
-    <listeners>
-        <listener
-        class="\Cake\TestSuite\Fixture\FixtureInjector"
-        file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
-            <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
-            </arguments>
-        </listener>
-    </listeners>
+    <extensions>
+        <extension class="Cake\TestSuite\Fixture\PHPUnitExtension"/>
+    </extensions>
+
+    <php>
+        <ini name="memory_limit" value="-1"/>
+
+        <!-- SQLite
+        <env name="DB_URL" value="sqlite:///:memory:"/>
+        -->
+        <!-- Postgres
+        <env name="DB_URL" value="postgres://localhost/cake_test?timezone=UTC"/>
+        -->
+        <!-- MySQL
+        <env name="DB_URL" value="mysql://localhost/cake_test?timezone=UTC"/>
+        -->
+        <!-- SQL Server
+        <env name="DB_URL" value="sqlserver://localhost/cake_test?timezone=UTC"/>
+        -->
+    </php>
 </phpunit>

--- a/src/Authentication/AuthenticationService.php
+++ b/src/Authentication/AuthenticationService.php
@@ -60,6 +60,7 @@ class AuthenticationService extends BaseService
 
         return $this->_result = $result;
     }
+
     /**
      * Proceed to webauthn2fa flow after a valid result result
      *

--- a/src/Authentication/AuthenticationService.php
+++ b/src/Authentication/AuthenticationService.php
@@ -123,7 +123,7 @@ class AuthenticationService extends BaseService
     /**
      * Get the configured u2f authentication checker
      *
-     * @return \CakeDC\Auth\Authentication\Webauthn2FAuthenticationCheckerInterface
+     * @return \CakeDC\Auth\Authentication\U2fAuthenticationCheckerInterface
      */
     protected function getU2fAuthenticationChecker()
     {

--- a/src/Authentication/AuthenticationService.php
+++ b/src/Authentication/AuthenticationService.php
@@ -17,6 +17,7 @@ use Authentication\AuthenticationService as BaseService;
 use Authentication\Authenticator\Result;
 use Authentication\Authenticator\ResultInterface;
 use Authentication\Authenticator\StatelessInterface;
+use Cake\Datasource\EntityInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 
@@ -37,9 +38,9 @@ class AuthenticationService extends BaseService
     /**
      * All failures authenticators
      *
-     * @var \CakeDC\Auth\Authentication\Failure[]
+     * @var array<\CakeDC\Auth\Authentication\Failure>
      */
-    protected $failures = [];
+    protected array $failures = [];
 
     /**
      * Proceed to google verify action after a valid result result
@@ -48,7 +49,7 @@ class AuthenticationService extends BaseService
      * @param \Authentication\Authenticator\ResultInterface $result The original result
      * @return \Authentication\Authenticator\ResultInterface The result object.
      */
-    protected function proceedToGoogleVerify(ServerRequestInterface $request, ResultInterface $result)
+    protected function proceedToGoogleVerify(ServerRequestInterface $request, ResultInterface $result): ResultInterface
     {
         /**
          * @var \Cake\Http\Session $session
@@ -68,7 +69,7 @@ class AuthenticationService extends BaseService
      * @param \Authentication\Authenticator\ResultInterface $result valid result
      * @return \Authentication\Authenticator\ResultInterface with result, request and response keys
      */
-    protected function proceedToWebauthn2fa(ServerRequestInterface $request, ResultInterface $result)
+    protected function proceedToWebauthn2fa(ServerRequestInterface $request, ResultInterface $result): ResultInterface
     {
         /**
          * @var \Cake\Http\Session $session
@@ -88,7 +89,7 @@ class AuthenticationService extends BaseService
      * @param \Authentication\Authenticator\ResultInterface $result valid result
      * @return \Authentication\Authenticator\ResultInterface with result, request and response keys
      */
-    protected function proceedToU2f(ServerRequestInterface $request, ResultInterface $result)
+    protected function proceedToU2f(ServerRequestInterface $request, ResultInterface $result): ResultInterface
     {
         /**
          * @var \Cake\Http\Session $session
@@ -106,7 +107,7 @@ class AuthenticationService extends BaseService
      *
      * @return \CakeDC\Auth\Authentication\OneTimePasswordAuthenticationCheckerInterface
      */
-    protected function getOneTimePasswordAuthenticationChecker()
+    protected function getOneTimePasswordAuthenticationChecker(): OneTimePasswordAuthenticationCheckerInterface
     {
         return (new OneTimePasswordAuthenticationCheckerFactory())->build();
     }
@@ -114,9 +115,9 @@ class AuthenticationService extends BaseService
     /**
      * Get the configured u2f authentication checker
      *
-     * @return \CakeDC\Auth\Authentication\Webauthn2FAuthenticationCheckerInterface
+     * @return \CakeDC\Auth\Authentication\Webauthn2fAuthenticationCheckerInterface
      */
-    protected function getWebauthn2fAuthenticationChecker()
+    protected function getWebauthn2fAuthenticationChecker(): Webauthn2fAuthenticationCheckerInterface
     {
         return (new Webauthn2fAuthenticationCheckerFactory())->build();
     }
@@ -126,7 +127,7 @@ class AuthenticationService extends BaseService
      *
      * @return \CakeDC\Auth\Authentication\U2fAuthenticationCheckerInterface
      */
-    protected function getU2fAuthenticationChecker()
+    protected function getU2fAuthenticationChecker(): U2fAuthenticationCheckerInterface
     {
         return (new U2fAuthenticationCheckerFactory())->build();
     }
@@ -145,11 +146,15 @@ class AuthenticationService extends BaseService
         }
 
         $result = null;
+        /** @var \Authentication\Authenticator\AbstractAuthenticator $authenticator */
         foreach ($this->authenticators() as $authenticator) {
             $result = $authenticator->authenticate($request);
             if ($result->isValid()) {
                 $skipTwoFactorVerify = $authenticator->getConfig('skipTwoFactorVerify');
-                $userData = $result->getData()->toArray();
+                $userData = $result->getData();
+                if ($userData instanceof EntityInterface) {
+                    $userData = $userData->toArray();
+                }
                 $webauthn2faChecker = $this->getWebauthn2fAuthenticationChecker();
                 if ($skipTwoFactorVerify !== true && $webauthn2faChecker->isRequired($userData)) {
                     return $this->proceedToWebauthn2fa($request, $result);
@@ -186,9 +191,9 @@ class AuthenticationService extends BaseService
     /**
      * Get list the list of failures processed
      *
-     * @return \CakeDC\Auth\Authentication\Failure[]
+     * @return array<\CakeDC\Auth\Authentication\Failure>
      */
-    public function getFailures()
+    public function getFailures(): array
     {
         return $this->failures;
     }

--- a/src/Authentication/AuthenticationService.php
+++ b/src/Authentication/AuthenticationService.php
@@ -183,6 +183,10 @@ class AuthenticationService extends BaseService
             }
         }
 
+        if ($result === null) {
+            $result = new Result(null, ResultInterface::FAILURE_OTHER);
+        }
+
         $this->_successfulAuthenticator = null;
 
         return $this->_result = $result;

--- a/src/Authentication/DefaultOneTimePasswordAuthenticationChecker.php
+++ b/src/Authentication/DefaultOneTimePasswordAuthenticationChecker.php
@@ -24,14 +24,14 @@ class DefaultOneTimePasswordAuthenticationChecker implements OneTimePasswordAuth
     /**
      * @var string
      */
-    protected $enabledKey = 'OneTimePasswordAuthenticator.login';
+    protected string $enabledKey = 'OneTimePasswordAuthenticator.login';
 
     /**
      * DefaultTwoFactorAuthenticationChecker constructor.
      *
      * @param string $enableKey configuration key to check if enabled
      */
-    public function __construct($enableKey = null)
+    public function __construct(?string $enableKey = null)
     {
         if ($enableKey !== null) {
             $this->enabledKey = $enableKey;
@@ -43,7 +43,7 @@ class DefaultOneTimePasswordAuthenticationChecker implements OneTimePasswordAuth
      *
      * @return bool
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return Configure::read($this->enabledKey) !== false;
     }
@@ -54,7 +54,7 @@ class DefaultOneTimePasswordAuthenticationChecker implements OneTimePasswordAuth
      * @param array<mixed>|null $user user data
      * @return bool
      */
-    public function isRequired(?array $user = null)
+    public function isRequired(?array $user = null): bool
     {
         return !empty($user) && $this->isEnabled();
     }

--- a/src/Authentication/DefaultOneTimePasswordAuthenticationChecker.php
+++ b/src/Authentication/DefaultOneTimePasswordAuthenticationChecker.php
@@ -51,7 +51,7 @@ class DefaultOneTimePasswordAuthenticationChecker implements OneTimePasswordAuth
     /**
      * Check if two factor authentication is required for a user
      *
-     * @param array|null $user user data
+     * @param array<mixed>|null $user user data
      * @return bool
      */
     public function isRequired(?array $user = null)

--- a/src/Authentication/DefaultOneTimePasswordAuthenticationChecker.php
+++ b/src/Authentication/DefaultOneTimePasswordAuthenticationChecker.php
@@ -51,7 +51,7 @@ class DefaultOneTimePasswordAuthenticationChecker implements OneTimePasswordAuth
     /**
      * Check if two factor authentication is required for a user
      *
-     * @param array $user user data
+     * @param array|null $user user data
      * @return bool
      */
     public function isRequired(?array $user = null)

--- a/src/Authentication/DefaultU2fAuthenticationChecker.php
+++ b/src/Authentication/DefaultU2fAuthenticationChecker.php
@@ -34,7 +34,7 @@ class DefaultU2fAuthenticationChecker implements U2fAuthenticationCheckerInterfa
     /**
      * Check if two factor authentication is required for a user
      *
-     * @param array $user user data
+     * @param array|null $user user data
      * @return bool
      */
     public function isRequired(?array $user = null)

--- a/src/Authentication/DefaultU2fAuthenticationChecker.php
+++ b/src/Authentication/DefaultU2fAuthenticationChecker.php
@@ -34,7 +34,7 @@ class DefaultU2fAuthenticationChecker implements U2fAuthenticationCheckerInterfa
     /**
      * Check if two factor authentication is required for a user
      *
-     * @param array|null $user user data
+     * @param array<mixed>|null $user user data
      * @return bool
      */
     public function isRequired(?array $user = null)

--- a/src/Authentication/DefaultU2fAuthenticationChecker.php
+++ b/src/Authentication/DefaultU2fAuthenticationChecker.php
@@ -26,7 +26,7 @@ class DefaultU2fAuthenticationChecker implements U2fAuthenticationCheckerInterfa
      *
      * @return bool
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return Configure::read('U2f.enabled') !== false;
     }
@@ -37,7 +37,7 @@ class DefaultU2fAuthenticationChecker implements U2fAuthenticationCheckerInterfa
      * @param array<mixed>|null $user user data
      * @return bool
      */
-    public function isRequired(?array $user = null)
+    public function isRequired(?array $user = null): bool
     {
         return !empty($user) && $this->isEnabled();
     }

--- a/src/Authentication/DefaultWebauthn2FAuthenticationChecker.php
+++ b/src/Authentication/DefaultWebauthn2FAuthenticationChecker.php
@@ -19,14 +19,14 @@ use Cake\Core\Configure;
  *
  * @package CakeDC\Auth\Auth
  */
-class DefaultWebauthn2fAuthenticationChecker implements Webauthn2fAuthenticationCheckerInterface
+class DefaultWebauthn2FAuthenticationChecker implements Webauthn2fAuthenticationCheckerInterface
 {
     /**
      * Check if two factor authentication is enabled
      *
      * @return bool
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return Configure::read('Webauthn2fa.enabled') !== false;
     }
@@ -37,7 +37,7 @@ class DefaultWebauthn2fAuthenticationChecker implements Webauthn2fAuthentication
      * @param array<mixed>|null $user user data
      * @return bool
      */
-    public function isRequired(?array $user = null)
+    public function isRequired(?array $user = null): bool
     {
         return !empty($user) && $this->isEnabled();
     }

--- a/src/Authentication/DefaultWebauthn2fAuthenticationChecker.php
+++ b/src/Authentication/DefaultWebauthn2fAuthenticationChecker.php
@@ -34,7 +34,7 @@ class DefaultWebauthn2fAuthenticationChecker implements Webauthn2fAuthentication
     /**
      * Check if two factor authentication is required for a user
      *
-     * @param array $user user data
+     * @param array<mixed>|null $user user data
      * @return bool
      */
     public function isRequired(?array $user = null)

--- a/src/Authentication/Failure.php
+++ b/src/Authentication/Failure.php
@@ -20,12 +20,12 @@ class Failure implements FailureInterface
     /**
      * @var \Authentication\Authenticator\AuthenticatorInterface
      */
-    protected $authenticator;
+    protected AuthenticatorInterface $authenticator;
 
     /**
      * @var \Authentication\Authenticator\ResultInterface
      */
-    protected $result;
+    protected ResultInterface $result;
 
     /**
      * Constructor.
@@ -44,7 +44,7 @@ class Failure implements FailureInterface
      *
      * @return \Authentication\Authenticator\AuthenticatorInterface
      */
-    public function getAuthenticator()
+    public function getAuthenticator(): AuthenticatorInterface
     {
         return $this->authenticator;
     }
@@ -54,7 +54,7 @@ class Failure implements FailureInterface
      *
      * @return \Authentication\Authenticator\ResultInterface
      */
-    public function getResult()
+    public function getResult(): ResultInterface
     {
         return $this->result;
     }

--- a/src/Authentication/FailureInterface.php
+++ b/src/Authentication/FailureInterface.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
  */
 namespace CakeDC\Auth\Authentication;
 
+use Authentication\Authenticator\AuthenticatorInterface;
+use Authentication\Authenticator\ResultInterface;
+
 interface FailureInterface
 {
     /**
@@ -19,12 +22,12 @@ interface FailureInterface
      *
      * @return \Authentication\Authenticator\AuthenticatorInterface
      */
-    public function getAuthenticator();
+    public function getAuthenticator(): AuthenticatorInterface;
 
     /**
      * Returns failed result.
      *
      * @return \Authentication\Authenticator\ResultInterface
      */
-    public function getResult();
+    public function getResult(): ResultInterface;
 }

--- a/src/Authentication/OneTimePasswordAuthenticationCheckerFactory.php
+++ b/src/Authentication/OneTimePasswordAuthenticationCheckerFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace CakeDC\Auth\Authentication;
 
 use Cake\Core\Configure;
+use InvalidArgumentException;
 
 /**
  * Factory for two authentication checker
@@ -26,7 +27,7 @@ class OneTimePasswordAuthenticationCheckerFactory
      *
      * @return \CakeDC\Auth\Authentication\OneTimePasswordAuthenticationCheckerInterface
      */
-    public function build()
+    public function build(): OneTimePasswordAuthenticationCheckerInterface
     {
         $className = Configure::read('OneTimePasswordAuthenticator.checker');
         $interfaces = class_implements($className);
@@ -35,6 +36,6 @@ class OneTimePasswordAuthenticationCheckerFactory
         if (in_array($required, $interfaces)) {
             return new $className();
         }
-        throw new \InvalidArgumentException("Invalid config for 'OneTimePasswordAuthenticator.checker', '$className' does not implement '$required'");
+        throw new InvalidArgumentException("Invalid config for 'OneTimePasswordAuthenticator.checker', '$className' does not implement '$required'");
     }
 }

--- a/src/Authentication/OneTimePasswordAuthenticationCheckerInterface.php
+++ b/src/Authentication/OneTimePasswordAuthenticationCheckerInterface.php
@@ -19,7 +19,7 @@ interface OneTimePasswordAuthenticationCheckerInterface
      *
      * @return bool
      */
-    public function isEnabled();
+    public function isEnabled(): bool;
 
     /**
      * Check if two factor authentication is required for a user
@@ -27,5 +27,5 @@ interface OneTimePasswordAuthenticationCheckerInterface
      * @param array<mixed>|null $user user data
      * @return bool
      */
-    public function isRequired(?array $user = null);
+    public function isRequired(?array $user = null): bool;
 }

--- a/src/Authentication/OneTimePasswordAuthenticationCheckerInterface.php
+++ b/src/Authentication/OneTimePasswordAuthenticationCheckerInterface.php
@@ -24,7 +24,7 @@ interface OneTimePasswordAuthenticationCheckerInterface
     /**
      * Check if two factor authentication is required for a user
      *
-     * @param array $user user data
+     * @param array<mixed>|null $user user data
      * @return bool
      */
     public function isRequired(?array $user = null);

--- a/src/Authentication/U2fAuthenticationCheckerFactory.php
+++ b/src/Authentication/U2fAuthenticationCheckerFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace CakeDC\Auth\Authentication;
 
 use Cake\Core\Configure;
+use InvalidArgumentException;
 
 /**
  * Factory for two authentication checker
@@ -26,7 +27,7 @@ class U2fAuthenticationCheckerFactory
      *
      * @return \CakeDC\Auth\Authentication\U2fAuthenticationCheckerInterface
      */
-    public function build()
+    public function build(): U2fAuthenticationCheckerInterface
     {
         $className = Configure::read('U2f.checker');
         $interfaces = class_implements($className);
@@ -35,6 +36,6 @@ class U2fAuthenticationCheckerFactory
         if (in_array($required, $interfaces)) {
             return new $className();
         }
-        throw new \InvalidArgumentException("Invalid config for 'U2f.checker', '$className' does not implement '$required'");
+        throw new InvalidArgumentException("Invalid config for 'U2f.checker', '$className' does not implement '$required'");
     }
 }

--- a/src/Authentication/U2fAuthenticationCheckerInterface.php
+++ b/src/Authentication/U2fAuthenticationCheckerInterface.php
@@ -24,7 +24,7 @@ interface U2fAuthenticationCheckerInterface
     /**
      * Check if two factor authentication is required for a user
      *
-     * @param array $user user data
+     * @param array<mixed>|null $user user data
      * @return bool
      */
     public function isRequired(?array $user = null);

--- a/src/Authentication/U2fAuthenticationCheckerInterface.php
+++ b/src/Authentication/U2fAuthenticationCheckerInterface.php
@@ -19,7 +19,7 @@ interface U2fAuthenticationCheckerInterface
      *
      * @return bool
      */
-    public function isEnabled();
+    public function isEnabled(): bool;
 
     /**
      * Check if two factor authentication is required for a user
@@ -27,5 +27,5 @@ interface U2fAuthenticationCheckerInterface
      * @param array<mixed>|null $user user data
      * @return bool
      */
-    public function isRequired(?array $user = null);
+    public function isRequired(?array $user = null): bool;
 }

--- a/src/Authentication/Webauthn2fAuthenticationCheckerFactory.php
+++ b/src/Authentication/Webauthn2fAuthenticationCheckerFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace CakeDC\Auth\Authentication;
 
 use Cake\Core\Configure;
+use InvalidArgumentException;
 
 /**
  * Factory for two authentication checker
@@ -24,17 +25,17 @@ class Webauthn2fAuthenticationCheckerFactory
     /**
      * Get the two factor authentication checker
      *
-     * @return \CakeDC\Auth\Authentication\Webauthn2FAuthenticationCheckerInterface
+     * @return \CakeDC\Auth\Authentication\Webauthn2fAuthenticationCheckerInterface
      */
-    public function build()
+    public function build(): Webauthn2fAuthenticationCheckerInterface
     {
         $className = Configure::read('Webauthn2fa.checker');
         $interfaces = class_implements($className);
-        $required = Webauthn2FAuthenticationCheckerInterface::class;
+        $required = Webauthn2fAuthenticationCheckerInterface::class;
 
         if (in_array($required, $interfaces)) {
             return new $className();
         }
-        throw new \InvalidArgumentException("Invalid config for 'Webauthn2fa.checker', '$className' does not implement '$required'");
+        throw new InvalidArgumentException("Invalid config for 'Webauthn2fa.checker', '$className' does not implement '$required'");
     }
 }

--- a/src/Authentication/Webauthn2fAuthenticationCheckerInterface.php
+++ b/src/Authentication/Webauthn2fAuthenticationCheckerInterface.php
@@ -24,7 +24,7 @@ interface Webauthn2FAuthenticationCheckerInterface
     /**
      * Check if two factor authentication is required for a user
      *
-     * @param array $user user data
+     * @param array<mixed>|null $user user data
      * @return bool
      */
     public function isRequired(?array $user = null);

--- a/src/Authentication/Webauthn2fAuthenticationCheckerInterface.php
+++ b/src/Authentication/Webauthn2fAuthenticationCheckerInterface.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
  */
 namespace CakeDC\Auth\Authentication;
 
-interface Webauthn2FAuthenticationCheckerInterface
+interface Webauthn2fAuthenticationCheckerInterface
 {
     /**
      * Check if two factor authentication is enabled
      *
      * @return bool
      */
-    public function isEnabled();
+    public function isEnabled(): bool;
 
     /**
      * Check if two factor authentication is required for a user
@@ -27,5 +27,5 @@ interface Webauthn2FAuthenticationCheckerInterface
      * @param array<mixed>|null $user user data
      * @return bool
      */
-    public function isRequired(?array $user = null);
+    public function isRequired(?array $user = null): bool;
 }

--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -34,7 +34,7 @@ class FormAuthenticator implements AuthenticatorInterface
      */
     public const FAILURE_INVALID_RECAPTCHA = 'FAILURE_INVALID_RECAPTCHA';
 
-    protected AuthenticatorInterface $baseAuthenticator;
+    protected ?AuthenticatorInterface $baseAuthenticator = null;
 
     /**
      * Identifier or identifiers collection.

--- a/src/Authenticator/FormAuthenticator.php
+++ b/src/Authenticator/FormAuthenticator.php
@@ -21,6 +21,7 @@ use Authentication\Identifier\IdentifierInterface;
 use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
 use CakeDC\Auth\Traits\ReCaptchaTrait;
+use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 
 class FormAuthenticator implements AuthenticatorInterface
@@ -33,24 +34,17 @@ class FormAuthenticator implements AuthenticatorInterface
      */
     public const FAILURE_INVALID_RECAPTCHA = 'FAILURE_INVALID_RECAPTCHA';
 
-    /**
-     * @var \Authentication\Authenticator\AuthenticatorInterface
-     */
-    protected $baseAuthenticator;
+    protected AuthenticatorInterface $baseAuthenticator;
 
     /**
      * Identifier or identifiers collection.
-     *
-     * @var \Authentication\Identifier\IdentifierInterface
      */
-    protected $identifier;
+    protected IdentifierInterface $identifier;
 
     /**
      * Settings for base authenticator
-     *
-     * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'keyCheckEnabledRecaptcha' => 'Users.reCaptcha.login',
     ];
 
@@ -71,9 +65,9 @@ class FormAuthenticator implements AuthenticatorInterface
      *
      * @return \Authentication\Authenticator\AuthenticatorInterface
      */
-    public function getBaseAuthenticator()
+    public function getBaseAuthenticator(): AuthenticatorInterface
     {
-        if ($this->baseAuthenticator === null) {
+        if (!isset($this->baseAuthenticator)) {
             $this->baseAuthenticator = $this->createBaseAuthenticator($this->identifier, $this->getConfig());
         }
 
@@ -87,7 +81,7 @@ class FormAuthenticator implements AuthenticatorInterface
      * @param array $config Configuration settings.
      * @return \Authentication\Authenticator\AuthenticatorInterface
      */
-    protected function createBaseAuthenticator(IdentifierInterface $identifier, array $config = [])
+    protected function createBaseAuthenticator(IdentifierInterface $identifier, array $config = []): AuthenticatorInterface
     {
         unset($config['keyCheckEnabledRecaptcha']);
         if (!isset($config['baseClassName'])) {
@@ -97,7 +91,7 @@ class FormAuthenticator implements AuthenticatorInterface
         $className = $config['baseClassName'];
         unset($config['baseClassName']);
         if (!class_exists($className)) {
-            throw new \InvalidArgumentException(__('Base class for FormAuthenticator {0} does not exist', $className));
+            throw new InvalidArgumentException(__('Base class for FormAuthenticator {0} does not exist', $className));
         }
 
         return new $className($identifier, $config);
@@ -134,7 +128,7 @@ class FormAuthenticator implements AuthenticatorInterface
      * @param array $arguments used in base authenticator method
      * @return mixed
      */
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments): mixed
     {
         return $this->getBaseAuthenticator()->$name(...$arguments);
     }

--- a/src/Authenticator/SocialAuthenticator.php
+++ b/src/Authenticator/SocialAuthenticator.php
@@ -108,7 +108,7 @@ class SocialAuthenticator extends AbstractAuthenticator
             $message = sprintf(
                 "Error getting an access token / retrieving the authorized user's profile data. Error message: %s %s",
                 $exception->getMessage(),
-                $exception
+                $exception::class
             );
             $this->log($message);
 

--- a/src/Authenticator/SocialAuthenticator.php
+++ b/src/Authenticator/SocialAuthenticator.php
@@ -22,7 +22,9 @@ use Cake\Log\LogTrait;
 use CakeDC\Auth\Identifier\SocialIdentifier;
 use CakeDC\Auth\Social\MapUser;
 use CakeDC\Auth\Social\Service\ServiceInterface;
+use Exception;
 use Psr\Http\Message\ServerRequestInterface;
+use UnexpectedValueException;
 
 /**
  * Social authenticator
@@ -44,7 +46,7 @@ class SocialAuthenticator extends AbstractAuthenticator
      *
      * @var array
      */
-    protected $_defaultConfig = [];
+    protected array $_defaultConfig = [];
 
     /**
      * Authenticates the identity contained in a request.
@@ -74,7 +76,7 @@ class SocialAuthenticator extends AbstractAuthenticator
      * @param array $rawData social user raw data
      * @return \Authentication\Authenticator\Result
      */
-    protected function identify($rawData)
+    protected function identify(array $rawData): Result
     {
         $user = $this->getIdentifier()->identify([SocialIdentifier::CREDENTIAL_KEY => $rawData]);
         if (!empty($user)) {
@@ -92,7 +94,7 @@ class SocialAuthenticator extends AbstractAuthenticator
      * @throws \Exception
      * @return array|null
      */
-    private function getRawData(ServerRequestInterface $request, ServiceInterface $service)
+    private function getRawData(ServerRequestInterface $request, ServiceInterface $service): ?array
     {
         $rawData = null;
         try {
@@ -100,8 +102,8 @@ class SocialAuthenticator extends AbstractAuthenticator
             $mapper = new MapUser();
 
             return $mapper($service, $rawData);
-        } catch (\Exception $exception) {
-            $list = [BadRequestException::class, \UnexpectedValueException::class];
+        } catch (Exception $exception) {
+            $list = [BadRequestException::class, UnexpectedValueException::class];
             $this->throwIfNotInlist($exception, $list);
             $message = sprintf(
                 "Error getting an access token / retrieving the authorized user's profile data. Error message: %s %s",
@@ -122,7 +124,7 @@ class SocialAuthenticator extends AbstractAuthenticator
      * @throws \Exception
      * @return void
      */
-    private function throwIfNotInlist(\Exception $exception, array $list)
+    private function throwIfNotInlist(Exception $exception, array $list): void
     {
         $className = get_class($exception);
         if (!in_array($className, $list)) {

--- a/src/Authenticator/TwoFactorAuthenticator.php
+++ b/src/Authenticator/TwoFactorAuthenticator.php
@@ -38,7 +38,7 @@ class TwoFactorAuthenticator extends AbstractAuthenticator
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'loginUrl' => null,
         'urlChecker' => 'Authentication.Default',
     ];
@@ -49,7 +49,7 @@ class TwoFactorAuthenticator extends AbstractAuthenticator
      * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
      * @return \Authentication\Authenticator\ResultInterface
      */
-    protected function _buildLoginUrlErrorResult($request)
+    protected function _buildLoginUrlErrorResult(ServerRequestInterface $request): ResultInterface
     {
         $errors = [
             sprintf(
@@ -80,7 +80,7 @@ class TwoFactorAuthenticator extends AbstractAuthenticator
          */
         $session = $request->getAttribute('session');
 
-        /** @var array|\ArrayAccess $data */
+        /** @var \ArrayAccess|array $data */
         $data = $session->read(self::USER_SESSION_KEY);
 
         if (!empty($data)) {

--- a/src/Controller/Component/OneTimePasswordAuthenticatorComponent.php
+++ b/src/Controller/Component/OneTimePasswordAuthenticatorComponent.php
@@ -27,7 +27,7 @@ class OneTimePasswordAuthenticatorComponent extends Component
     /**
      * @var \RobThree\Auth\TwoFactorAuth $tfa
      */
-    public $tfa;
+    public TwoFactorAuth $tfa;
 
     /**
      * initialize method
@@ -56,7 +56,7 @@ class OneTimePasswordAuthenticatorComponent extends Component
      *
      * @return string base32 shared secret stored in users table
      */
-    public function createSecret()
+    public function createSecret(): string
     {
         return $this->tfa->createSecret();
     }
@@ -69,7 +69,7 @@ class OneTimePasswordAuthenticatorComponent extends Component
      * @param string $code from verification form
      * @return bool
      */
-    public function verifyCode($secret, $code)
+    public function verifyCode(string $secret, string $code): bool
     {
         return $this->tfa->verifyCode($secret, $code);
     }
@@ -81,7 +81,7 @@ class OneTimePasswordAuthenticatorComponent extends Component
      * @param string $secret secret
      * @return string base64 string containing QR code for shared secret
      */
-    public function getQRCodeImageAsDataUri($issuer, $secret)
+    public function getQRCodeImageAsDataUri(string $issuer, string $secret): string
     {
         return $this->tfa->getQRCodeImageAsDataUri($issuer, $secret);
     }

--- a/src/Exception/InvalidProviderException.php
+++ b/src/Exception/InvalidProviderException.php
@@ -20,6 +20,7 @@ class InvalidProviderException extends CakeException
     protected string $_messageTemplate = 'Invalid provider or missing class (%s)';
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var int
      */
     protected $code = 500;

--- a/src/Exception/InvalidProviderException.php
+++ b/src/Exception/InvalidProviderException.php
@@ -17,7 +17,11 @@ use Cake\Core\Exception\CakeException;
 
 class InvalidProviderException extends CakeException
 {
-    protected $_messageTemplate = 'Invalid provider or missing class (%s)';
+    protected string $_messageTemplate = 'Invalid provider or missing class (%s)';
+
+    /**
+     * @var int
+     */
     protected $code = 500;
 
     /**
@@ -27,7 +31,7 @@ class InvalidProviderException extends CakeException
      * @param int $code code
      * @param null $previous previous
      */
-    public function __construct($message, $code = 500, $previous = null)
+    public function __construct(array|string $message, int $code = 500, $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/InvalidSettingsException.php
+++ b/src/Exception/InvalidSettingsException.php
@@ -20,6 +20,7 @@ class InvalidSettingsException extends CakeException
     protected string $_messageTemplate = 'Invalid settings for key (%s)';
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var int
      */
     protected $code = 500;

--- a/src/Exception/InvalidSettingsException.php
+++ b/src/Exception/InvalidSettingsException.php
@@ -17,7 +17,11 @@ use Cake\Core\Exception\CakeException;
 
 class InvalidSettingsException extends CakeException
 {
-    protected $_messageTemplate = 'Invalid settings for key (%s)';
+    protected string $_messageTemplate = 'Invalid settings for key (%s)';
+
+    /**
+     * @var int
+     */
     protected $code = 500;
 
     /**
@@ -27,7 +31,7 @@ class InvalidSettingsException extends CakeException
      * @param int $code code
      * @param null $previous previous
      */
-    public function __construct($message, $code = 500, $previous = null)
+    public function __construct(array|string $message, int $code = 500, $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Identifier/SocialIdentifier.php
+++ b/src/Identifier/SocialIdentifier.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CakeDC\Auth\Identifier;
 
+use ArrayAccess;
 use Authentication\Identifier\AbstractIdentifier;
 use Authentication\Identifier\Resolver\ResolverAwareTrait;
 
@@ -22,7 +23,7 @@ class SocialIdentifier extends AbstractIdentifier
 
     public const CREDENTIAL_KEY = 'socialAuthUser';
 
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'resolver' => 'Authentication.Orm',
     ];
 
@@ -32,7 +33,7 @@ class SocialIdentifier extends AbstractIdentifier
      * @param array $credentials Authentication credentials
      * @return \ArrayAccess|array|null
      */
-    public function identify(array $credentials)
+    public function identify(array $credentials): ArrayAccess|array|null
     {
         if (!isset($credentials[self::CREDENTIAL_KEY]['email'])) {
             return null;

--- a/src/Middleware/RbacMiddleware.php
+++ b/src/Middleware/RbacMiddleware.php
@@ -171,7 +171,7 @@ class RbacMiddleware implements MiddlewareInterface
         if ($behavior === self::UNAUTHORIZED_BEHAVIOR_THROW) {
             throw new ForbiddenException();
         }
-        $accept = (array)$request->getHeader('Accept');
+        $accept = $request->getHeader('Accept');
         if (
             $behavior === self::UNAUTHORIZED_BEHAVIOR_AUTO &&
             in_array('application/json', $accept, true)

--- a/src/Middleware/RbacMiddleware.php
+++ b/src/Middleware/RbacMiddleware.php
@@ -95,7 +95,7 @@ class RbacMiddleware implements MiddlewareInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         /*
          * Manage what to do if the request is not authorized,
          * throw - throw a ForbiddenException
@@ -116,7 +116,7 @@ class RbacMiddleware implements MiddlewareInterface
     /**
      * @var \CakeDC\Auth\Rbac\Rbac
      */
-    protected $rbac;
+    protected Rbac $rbac;
 
     /**
      * RbacMiddleware constructor
@@ -187,7 +187,7 @@ class RbacMiddleware implements MiddlewareInterface
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    protected function unauthorizedRedirect()
+    protected function unauthorizedRedirect(): ResponseInterface
     {
         $url = $this->getConfig('unauthorizedRedirect');
 

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -35,7 +35,7 @@ class SocialAuthMiddleware implements MiddlewareInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'loginUrl' => false,
         'urlChecker' => 'Authentication.Default',
     ];
@@ -75,7 +75,7 @@ class SocialAuthMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @return bool
      */
-    protected function checkUrl(ServerRequestInterface $request)
+    protected function checkUrl(ServerRequestInterface $request): bool
     {
         return $this->_getUrlChecker()->check($request, $this->getConfig('loginUrl'));
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 namespace CakeDC\Auth;
 
 use Cake\Core\BasePlugin;
+use Cake\Core\Configure;
+use Cake\Routing\RouteBuilder;
 
 /**
  * Class Plugin
@@ -21,4 +23,20 @@ use Cake\Core\BasePlugin;
  */
 class Plugin extends BasePlugin
 {
+    /**
+     * @inheritDoc
+     */
+    public function routes(RouteBuilder $routes): void
+    {
+        $oauthPath = Configure::read('OAuth.path');
+        if (is_array($oauthPath)) {
+            $routes->scope('/auth', function ($routes) use ($oauthPath): void {
+                $routes->connect(
+                    '/:provider',
+                    $oauthPath,
+                    ['provider' => implode('|', array_keys(Configure::read('OAuth.providers')))]
+                );
+            });
+        }
+    }
 }

--- a/src/Policy/CollectionPolicy.php
+++ b/src/Policy/CollectionPolicy.php
@@ -28,7 +28,7 @@ class CollectionPolicy
      *
      * @var array
      */
-    protected $policies;
+    protected array $policies;
 
     /**
      * CollectionPolicy constructor.

--- a/src/Policy/RbacPolicy.php
+++ b/src/Policy/RbacPolicy.php
@@ -37,10 +37,8 @@ class RbacPolicy implements PolicyInterface
 
     /**
      * Cached instance of the rbac, we don't need to build more than 1 per request
-     *
-     * @var \CakeDC\Auth\Rbac\RbacInterface|null
      */
-    protected RbacInterface $createdRbac;
+    protected ?RbacInterface $createdRbac;
 
     /**
      * RbacPolicy constructor.

--- a/src/Policy/RbacPolicy.php
+++ b/src/Policy/RbacPolicy.php
@@ -17,6 +17,7 @@ use Authorization\IdentityInterface;
 use Cake\Core\InstanceConfigTrait;
 use CakeDC\Auth\Rbac\Rbac;
 use CakeDC\Auth\Rbac\RbacInterface;
+use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 
 class RbacPolicy implements PolicyInterface
@@ -28,7 +29,7 @@ class RbacPolicy implements PolicyInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'adapter' => [
             'className' => Rbac::class,
         ],
@@ -39,7 +40,7 @@ class RbacPolicy implements PolicyInterface
      *
      * @var \CakeDC\Auth\Rbac\RbacInterface
      */
-    protected $createdRbac;
+    protected RbacInterface $createdRbac;
 
     /**
      * RbacPolicy constructor.
@@ -74,7 +75,7 @@ class RbacPolicy implements PolicyInterface
      * @param \Psr\Http\Message\ServerRequestInterface $resource server request
      * @return \CakeDC\Auth\Rbac\RbacInterface
      */
-    public function getRbac($resource): RbacInterface
+    public function getRbac(ServerRequestInterface $resource): RbacInterface
     {
         $rbac = $resource->getAttribute('rbac');
         if ($rbac !== null) {
@@ -83,7 +84,7 @@ class RbacPolicy implements PolicyInterface
 
         $adapter = $this->getConfig('adapter');
         if (is_array($adapter)) {
-            if ($this->createdRbac) {
+            if (isset($this->createdRbac)) {
                 return $this->createdRbac;
             }
             $this->createdRbac = $this->createRbac($adapter);
@@ -101,7 +102,7 @@ class RbacPolicy implements PolicyInterface
      * @throws \InvalidArgumentException When 'key' className is missing in $config
      * @return \CakeDC\Auth\Rbac\RbacInterface
      */
-    protected function createRbac($config): RbacInterface
+    protected function createRbac(array $config): RbacInterface
     {
         if (isset($config['className'])) {
             $className = $config['className'];
@@ -113,6 +114,6 @@ class RbacPolicy implements PolicyInterface
             }
         }
 
-        throw new \InvalidArgumentException('Config "adapter" should be an object or an array with key className');
+        throw new InvalidArgumentException('Config "adapter" should be an object or an array with key className');
     }
 }

--- a/src/Policy/RbacPolicy.php
+++ b/src/Policy/RbacPolicy.php
@@ -63,7 +63,7 @@ class RbacPolicy implements PolicyInterface
 
         $user = $identity !== null ? $identity->getOriginalData() : [];
 
-        return (bool)$rbac->checkPermissions($user, $resource);
+        return $rbac->checkPermissions($user, $resource);
     }
 
     /**

--- a/src/Policy/SuperuserPolicy.php
+++ b/src/Policy/SuperuserPolicy.php
@@ -30,7 +30,7 @@ class SuperuserPolicy implements PolicyInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         //superuser field in the Users table
         'superuser_field' => 'is_superuser',
     ];

--- a/src/Rbac/PermissionMatchResult.php
+++ b/src/Rbac/PermissionMatchResult.php
@@ -48,7 +48,7 @@ class PermissionMatchResult
      */
     public function setAllowed(bool $allowed): PermissionMatchResult
     {
-        $this->_allowed = (bool)$allowed;
+        $this->_allowed = $allowed;
 
         return $this;
     }
@@ -66,7 +66,7 @@ class PermissionMatchResult
      */
     public function setReason(string $reason): PermissionMatchResult
     {
-        $this->_reason = (string)$reason;
+        $this->_reason = $reason;
 
         return $this;
     }

--- a/src/Rbac/PermissionMatchResult.php
+++ b/src/Rbac/PermissionMatchResult.php
@@ -24,12 +24,12 @@ class PermissionMatchResult
     /**
      * @var bool
      */
-    protected $_allowed;
+    protected bool $_allowed;
 
     /**
      * @var string
      */
-    protected $_reason;
+    protected string $_reason;
 
     /**
      * PermissionMatchResult constructor.
@@ -37,7 +37,7 @@ class PermissionMatchResult
      * @param bool $allowed rule was matched, allowed value
      * @param string $reason reason to either allow or deny
      */
-    public function __construct($allowed = false, $reason = '')
+    public function __construct(bool $allowed = false, string $reason = '')
     {
         $this->_allowed = $allowed;
         $this->_reason = $reason;
@@ -45,9 +45,8 @@ class PermissionMatchResult
 
     /**
      * @param bool $allowed allowed value
-     * @return \CakeDC\Auth\Rbac\PermissionMatchResult
      */
-    public function setAllowed($allowed)
+    public function setAllowed(bool $allowed): PermissionMatchResult
     {
         $this->_allowed = (bool)$allowed;
 
@@ -57,16 +56,15 @@ class PermissionMatchResult
     /**
      * @return bool
      */
-    public function isAllowed()
+    public function isAllowed(): bool
     {
         return $this->_allowed;
     }
 
     /**
      * @param string $reason reason
-     * @return \CakeDC\Auth\Rbac\PermissionMatchResult
      */
-    public function setReason($reason)
+    public function setReason(string $reason): PermissionMatchResult
     {
         $this->_reason = (string)$reason;
 
@@ -76,7 +74,7 @@ class PermissionMatchResult
     /**
      * @return string
      */
-    public function getReason()
+    public function getReason(): string
     {
         return $this->_reason;
     }

--- a/src/Rbac/Permissions/AbstractProvider.php
+++ b/src/Rbac/Permissions/AbstractProvider.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace CakeDC\Auth\Rbac\Permissions;
 
 use Cake\Core\InstanceConfigTrait;
+use Cake\Http\ServerRequest;
 use Cake\Log\LogTrait;
+use Cake\Utility\Hash;
 
 /**
  * Class AbstractProvider, handles getting permission from different sources,
@@ -30,14 +32,14 @@ abstract class AbstractProvider
      *
      * @var array
      */
-    protected $defaultPermissions;
+    protected array $defaultPermissions;
 
     /**
      * AbstractProvider constructor.
      *
      * @param array $config config
      */
-    public function __construct($config = [])
+    public function __construct(array $config = [])
     {
         $this->setConfig($config);
         $this->defaultPermissions = [
@@ -97,8 +99,8 @@ abstract class AbstractProvider
                 'plugin' => 'CakeDC/Users',
                 'controller' => 'Users',
                 'action' => 'resetOneTimePasswordAuthenticator',
-                'allowed' => function (array $user, string $role, \Cake\Http\ServerRequest $request): bool {
-                    $userId = \Cake\Utility\Hash::get($request->getAttribute('params'), 'pass.0');
+                'allowed' => function (array $user, string $role, ServerRequest $request): bool {
+                    $userId = Hash::get($request->getAttribute('params'), 'pass.0');
                     if (!empty($userId) && !empty($user)) {
                         return $userId === $user['id'];
                     }
@@ -128,12 +130,12 @@ abstract class AbstractProvider
      *
      * @return array Array of permissions
      */
-    abstract public function getPermissions();
+    abstract public function getPermissions(): array;
 
     /**
      * @return array
      */
-    public function getDefaultPermissions()
+    public function getDefaultPermissions(): array
     {
         return $this->defaultPermissions;
     }
@@ -142,7 +144,7 @@ abstract class AbstractProvider
      * @param array $defaultPermissions default permissions
      * @return void
      */
-    public function setDefaultPermissions($defaultPermissions)
+    public function setDefaultPermissions(array $defaultPermissions): void
     {
         $this->defaultPermissions = $defaultPermissions;
     }

--- a/src/Rbac/Permissions/ConfigProvider.php
+++ b/src/Rbac/Permissions/ConfigProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CakeDC\Auth\Rbac\Permissions;
 
 use Cake\Core\Configure;
+use Exception;
 use Psr\Log\LogLevel;
 
 /**
@@ -26,7 +27,7 @@ class ConfigProvider extends AbstractProvider
     /**
      * @var array default configuration
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'autoload_config' => 'permissions',
     ];
 
@@ -35,7 +36,7 @@ class ConfigProvider extends AbstractProvider
      *
      * @return array Array of permissions
      */
-    public function getPermissions()
+    public function getPermissions(): array
     {
         $autoload = $this->getConfig('autoload_config');
 
@@ -64,7 +65,7 @@ class ConfigProvider extends AbstractProvider
      * @param string $key name of the configuration file to read permissions from
      * @return array permissions
      */
-    protected function _loadPermissions($key)
+    protected function _loadPermissions(string $key): array
     {
         $permissions = null;
         try {
@@ -74,7 +75,7 @@ class ConfigProvider extends AbstractProvider
             if (!$permissions && $legacyPermissions) {
                 $permissions = $legacyPermissions;
             }
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             $msg = sprintf('Missing configuration file: "config/%s.php". Using default permissions', $key);
             $this->log($msg, LogLevel::WARNING);
         }

--- a/src/Rbac/Rbac.php
+++ b/src/Rbac/Rbac.php
@@ -226,10 +226,11 @@ class Rbac implements RbacInterface
     protected function _matchOrAsterisk($possibleValues, $value, $allowEmpty = false)
     {
         $possibleArray = (array)$possibleValues;
+
         return $possibleValues === '*' ||
-        $value === $possibleValues ||
-        in_array($value, $possibleArray) ||
-        in_array(Inflector::camelize((string)$value, '-'), $possibleArray);
+            $value === $possibleValues ||
+            in_array($value, $possibleArray) ||
+            in_array(Inflector::camelize((string)$value, '-'), $possibleArray);
     }
 
     /**

--- a/src/Rbac/Rbac.php
+++ b/src/Rbac/Rbac.php
@@ -80,6 +80,7 @@ class Rbac implements RbacInterface
             if (!is_subclass_of($permissionsProviderClass, AbstractProvider::class)) {
                 throw new RuntimeException(sprintf('Class "%s" must extend AbstractProvider', $permissionsProviderClass));
             }
+            /** @psalm-suppress UnsafeInstantiation */
             $permissionsProvider = new $permissionsProviderClass([
                 'autoload_config' => $this->getConfig('autoload_config'),
             ]);
@@ -182,19 +183,19 @@ class Rbac implements RbacInterface
             if (!is_string($value) && is_callable($value)) {
                 $return = (bool)call_user_func($value, $user, $role, $request);
             } elseif ($value instanceof Rule) {
-                $return = (bool)$value->allowed($user, $role, $request);
+                $return = $value->allowed($user, $role, $request);
             } elseif ($key === 'bypassAuth' && $value === true) {
                 $return = true;
             } elseif ($key === 'allowed') {
-                $return = !empty($user) && (bool)$value;
+                $return = !empty($user) && $value;
             } elseif (array_key_exists($key, $reserved)) {
                 $return = $this->_matchOrAsterisk($value, $reserved[$key], true);
             } else {
-                if (!$this->_startsWith((string)$key, 'user.')) {
+                if (!$this->_startsWith($key, 'user.')) {
                     $key = 'user.' . $key;
                 }
 
-                $return = $this->_matchOrAsterisk($value, Hash::get($userArr, (string)$key));
+                $return = $this->_matchOrAsterisk($value, Hash::get($userArr, $key));
             }
 
             if ($inverse) {

--- a/src/Rbac/RbacInterface.php
+++ b/src/Rbac/RbacInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CakeDC\Auth\Rbac;
 
+use ArrayAccess;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -25,21 +26,21 @@ interface RbacInterface
     /**
      * @return array
      */
-    public function getPermissions();
+    public function getPermissions(): array;
 
     /**
      * @param array $permissions permissions
      * @return void
      */
-    public function setPermissions($permissions);
+    public function setPermissions(array $permissions): void;
 
     /**
      * Match against permissions, return if matched
      * Permissions are processed based on the 'permissions' config values
      *
-     * @param array|\ArrayAccess $user current user array
+     * @param \ArrayAccess|array $user current user array
      * @param \Psr\Http\Message\ServerRequestInterface $request request
      * @return bool true if there is a match in permissions
      */
-    public function checkPermissions($user, ServerRequestInterface $request);
+    public function checkPermissions(array|ArrayAccess $user, ServerRequestInterface $request): bool;
 }

--- a/src/Rbac/Rules/AbstractRule.php
+++ b/src/Rbac/Rules/AbstractRule.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
  */
 namespace CakeDC\Auth\Rbac\Rules;
 
+use ArrayAccess;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Datasource\ModelAwareTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -23,26 +23,24 @@ use Psr\Http\Message\ServerRequestInterface;
 /**
  * Class AbstractRule
  *
- * @method \Cake\ORM\Table loadModel($modelClass = null, $modelType = null)
  * @package CakeDC\Auth\Auth\Rules
  */
 abstract class AbstractRule implements Rule
 {
     use InstanceConfigTrait;
     use LocatorAwareTrait;
-    use ModelAwareTrait;
 
     /**
      * @var array default config
      */
-    protected $_defaultConfig = [];
+    protected array $_defaultConfig = [];
 
     /**
      * AbstractRule constructor.
      *
      * @param array $config Rule config
      */
-    public function __construct($config = [])
+    public function __construct(array $config = [])
     {
         $this->setConfig($config);
     }
@@ -54,7 +52,7 @@ abstract class AbstractRule implements Rule
      * @param mixed $table table
      * @return \Cake\ORM\Table
      */
-    protected function _getTable(ServerRequestInterface $request, $table = null)
+    protected function _getTable(ServerRequestInterface $request, mixed $table = null): Table
     {
         if (empty($table)) {
             return $this->_getTableFromRequest($request);
@@ -73,32 +71,28 @@ abstract class AbstractRule implements Rule
      * @return \Cake\ORM\Table
      * @throws \OutOfBoundsException if table alias can't be extracted from request
      */
-    protected function _getTableFromRequest(ServerRequestInterface $request)
+    protected function _getTableFromRequest(ServerRequestInterface $request): Table
     {
         $params = $request->getAttribute('params');
 
         $plugin = $params['plugin'] ?? null;
         $controller = $params['controller'] ?? null;
         $modelClass = ($plugin ? $plugin . '.' : '') . $controller;
-
-        $this->modelFactory('Table', function (string $alias, array $options): \Cake\ORM\Table {
-            return $this->getTableLocator()->get($alias, $options);
-        });
         if (empty($modelClass)) {
             throw new OutOfBoundsException('Missing Table alias, we could not extract a default table from the request');
         }
 
-        return $this->loadModel($modelClass);
+        return $this->fetchTable($modelClass);
     }
 
     /**
      * Check the current entity is owned by the logged in user
      *
-     * @param array|\ArrayAccess $user Auth array with the logged in data
+     * @param \ArrayAccess|array $user Auth array with the logged in data
      * @param string $role role of the user
      * @param \Psr\Http\Message\ServerRequestInterface $request current request, used to get a default table if not provided
      * @return bool
      * @throws \OutOfBoundsException if table is not found or it doesn't have the expected fields
      */
-    abstract public function allowed($user, $role, ServerRequestInterface $request);
+    abstract public function allowed(array|ArrayAccess $user, string $role, ServerRequestInterface $request): bool;
 }

--- a/src/Rbac/Rules/AbstractRule.php
+++ b/src/Rbac/Rules/AbstractRule.php
@@ -81,7 +81,7 @@ abstract class AbstractRule implements Rule
         $controller = $params['controller'] ?? null;
         $modelClass = ($plugin ? $plugin . '.' : '') . $controller;
 
-        $this->modelFactory('Table', function (string $alias, array $options) : \Cake\ORM\Table {
+        $this->modelFactory('Table', function (string $alias, array $options): \Cake\ORM\Table {
             return $this->getTableLocator()->get($alias, $options);
         });
         if (empty($modelClass)) {

--- a/src/Rbac/Rules/Owner.php
+++ b/src/Rbac/Rules/Owner.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
  */
 namespace CakeDC\Auth\Rbac\Rules;
 
-use Cake\Core\Exception\CakeException;
 use Cake\Utility\Hash;
 use OutOfBoundsException;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/Rbac/Rules/Owner.php
+++ b/src/Rbac/Rules/Owner.php
@@ -73,11 +73,12 @@ class Owner extends AbstractRule
             return false;
         }
 
+        $ownerForeignKey = $this->getConfig('ownerForeignKey');
         try {
-            if (!$table->hasField($this->getConfig('ownerForeignKey'))) {
+            if (!$table->hasField($ownerForeignKey)) {
                 $msg = sprintf(
                     'Missing column %s in table %s while checking ownership permissions for user %s',
-                    $this->getConfig('ownerForeignKey'),
+                    $ownerForeignKey,
                     $table->getAlias(),
                     $userId
                 );
@@ -86,7 +87,7 @@ class Owner extends AbstractRule
         } catch (CakeException $ex) {
             $msg = sprintf(
                 'Missing column %s in table %s while checking ownership permissions for user %s',
-                $this->getConfig('ownerForeignKey'),
+                $ownerForeignKey,
                 $table->getAlias(),
                 $userId
             );
@@ -96,9 +97,10 @@ class Owner extends AbstractRule
         if (empty($idColumn)) {
             $idColumn = $table->getPrimaryKey();
         }
+        /** @psalm-suppress InvalidArrayOffset */
         $conditions = array_merge([
             $idColumn => $id,
-            $this->getConfig('ownerForeignKey') => $userId,
+            $ownerForeignKey => $userId,
         ], $this->getConfig('conditions'));
 
         return $table->exists($conditions);

--- a/src/Rbac/Rules/Rule.php
+++ b/src/Rbac/Rules/Rule.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
  */
 namespace CakeDC\Auth\Rbac\Rules;
 
+use ArrayAccess;
 use Psr\Http\Message\ServerRequestInterface;
 
 interface Rule
@@ -19,10 +20,10 @@ interface Rule
     /**
      * Check the current entity is owned by the logged in user
      *
-     * @param array|\ArrayAccess $user Auth array with the logged in data
+     * @param \ArrayAccess|array $user Auth array with the logged in data
      * @param string $role role of the user
      * @param \Psr\Http\Message\ServerRequestInterface $request current request, used to get a default table if not provided
      * @return bool
      */
-    public function allowed($user, $role, ServerRequestInterface $request);
+    public function allowed(array|ArrayAccess $user, string $role, ServerRequestInterface $request): bool;
 }

--- a/src/Rbac/Rules/RuleRegistry.php
+++ b/src/Rbac/Rules/RuleRegistry.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CakeDC\Auth\Rbac\Rules;
 
 use BadMethodCallException;
-use function json_encode;
 
 /**
  * Static rule registry to allow reusing rule instances in Rbac permissions

--- a/src/Rbac/Rules/RuleRegistry.php
+++ b/src/Rbac/Rules/RuleRegistry.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace CakeDC\Auth\Rbac\Rules;
 
+use BadMethodCallException;
+use function json_encode;
+
 /**
  * Static rule registry to allow reusing rule instances in Rbac permissions
  */
@@ -23,7 +26,7 @@ class RuleRegistry
      *
      * @var array
      */
-    protected static $rules = [];
+    protected static array $rules = [];
 
     /**
      * Get a new Rule instance by class, construct a new instance if not found
@@ -35,9 +38,9 @@ class RuleRegistry
     public static function get(string $class, ?array $config = []): Rule
     {
         if (!class_exists($class)) {
-            throw new \BadMethodCallException(sprintf('Unknown rule class %s', $class));
+            throw new BadMethodCallException(sprintf('Unknown rule class %s', $class));
         }
-        $key = $class . md5(\json_encode($config));
+        $key = $class . md5(json_encode($config));
         if (!isset(static::$rules[$key])) {
             $ruleInstance = new $class($config);
             static::$rules[$key] = $ruleInstance;

--- a/src/Social/MapUser.php
+++ b/src/Social/MapUser.php
@@ -13,16 +13,19 @@ declare(strict_types=1);
 
 namespace CakeDC\Auth\Social;
 
+use CakeDC\Auth\Social\Service\ServiceInterface;
+use InvalidArgumentException;
+
 class MapUser
 {
     /**
      * Map social user user data
      *
      * @param \CakeDC\Auth\Social\Service\ServiceInterface $service social service
-     * @param array $data user social data
+     * @param mixed $data user social data
      * @return mixed
      */
-    public function __invoke($service, $data)
+    public function __invoke(ServiceInterface $service, mixed $data): mixed
     {
         $mapper = $service->getConfig('mapper');
         if (is_string($mapper)) {
@@ -39,12 +42,12 @@ class MapUser
      * Build the mapper object
      *
      * @param string $className of mapper
-     * @return \Closure
+     * @return object
      */
-    protected function buildMapper(string $className)
+    protected function buildMapper(string $className): object
     {
         if (!class_exists($className)) {
-            throw new \InvalidArgumentException(__('Provider mapper class {0} does not exist', $className));
+            throw new InvalidArgumentException(__('Provider mapper class {0} does not exist', $className));
         }
 
         return new $className();

--- a/src/Social/Mapper/AbstractMapper.php
+++ b/src/Social/Mapper/AbstractMapper.php
@@ -15,6 +15,7 @@ namespace CakeDC\Auth\Social\Mapper;
 
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
+use League\OAuth2\Client\Token\AccessToken;
 
 /**
  * AbstractMapper
@@ -26,21 +27,21 @@ abstract class AbstractMapper
      *
      * @var array
      */
-    protected $_rawData = [];
+    protected array $_rawData = [];
 
     /**
      * Map for provider fields
      *
      * @var array
      */
-    protected $_mapFields = [];
+    protected array $_mapFields = [];
 
     /**
      * Default Map for provider fields
      *
      * @var array
      */
-    protected $_defaultMapFields = [
+    protected array $_defaultMapFields = [
         'id' => 'id',
         'username' => 'username',
         'full_name' => 'name',
@@ -60,7 +61,7 @@ abstract class AbstractMapper
      *
      * @param mixed $mapFields map fields
      */
-    public function __construct($mapFields = null)
+    public function __construct(mixed $mapFields = null)
     {
         if (!is_null($mapFields)) {
             $this->_mapFields = $mapFields;
@@ -74,7 +75,7 @@ abstract class AbstractMapper
      * @param mixed $rawData raw data
      * @return mixed
      */
-    public function __invoke($rawData)
+    public function __invoke(mixed $rawData): mixed
     {
         return $this->_map($rawData);
     }
@@ -85,7 +86,7 @@ abstract class AbstractMapper
      * @param mixed $rawData raw data
      * @return bool
      */
-    protected function _validated($rawData)
+    protected function _validated(mixed $rawData): bool
     {
         $email = Hash::get($rawData, $this->_mapFields['email']);
 
@@ -98,7 +99,7 @@ abstract class AbstractMapper
      * @param mixed $rawData raw data
      * @return mixed
      */
-    protected function _map($rawData)
+    protected function _map(mixed $rawData): mixed
     {
         $result = [];
         collection($this->_mapFields)->each(function (string $mappedField, string $field) use (&$result, $rawData): void {
@@ -110,7 +111,7 @@ abstract class AbstractMapper
             $result[$field] = $value;
         });
         $token = $rawData['token'] ?? null;
-        if (empty($token) || !is_array($token) && !$token instanceof \League\OAuth2\Client\Token\AccessToken) {
+        if (empty($token) || !is_array($token) && !$token instanceof AccessToken) {
             return false;
         }
 

--- a/src/Social/Mapper/Amazon.php
+++ b/src/Social/Mapper/Amazon.php
@@ -30,7 +30,7 @@ class Amazon extends AbstractMapper
      *
      * @var array
      */
-    protected $_mapFields = [
+    protected array $_mapFields = [
         'id' => 'user_id',
     ];
 
@@ -40,7 +40,7 @@ class Amazon extends AbstractMapper
      * @param mixed $rawData raw data
      * @return string
      */
-    protected function _link($rawData)
+    protected function _link(mixed $rawData): string
     {
         return self::AMAZON_BASE_URL . Hash::get($rawData, $this->_mapFields['id']);
     }

--- a/src/Social/Mapper/Cognito.php
+++ b/src/Social/Mapper/Cognito.php
@@ -25,7 +25,7 @@ class Cognito extends AbstractMapper
      *
      * @var array
      */
-    protected $_mapFields = [
+    protected array $_mapFields = [
         'id' => 'sub',
         'zoneinfo' => 'zoneinfo',
         'link' => 'website',
@@ -41,7 +41,7 @@ class Cognito extends AbstractMapper
      * @param mixed $rawData raw data
      * @return string
      */
-    protected function _link($rawData)
+    protected function _link(mixed $rawData): string
     {
         return Hash::get($rawData, $this->_mapFields['link'], '#');
     }
@@ -52,7 +52,7 @@ class Cognito extends AbstractMapper
      * @param mixed $rawData raw data
      * @return mixed
      */
-    protected function _firstName($rawData)
+    protected function _firstName(mixed $rawData): mixed
     {
         return $this->getNameValue($rawData, 'first_name', 0);
     }
@@ -63,7 +63,7 @@ class Cognito extends AbstractMapper
      * @param mixed $rawData raw data
      * @return mixed
      */
-    protected function _lastName($rawData)
+    protected function _lastName(mixed $rawData): mixed
     {
         return $this->getNameValue($rawData, 'last_name', 1);
     }
@@ -76,7 +76,7 @@ class Cognito extends AbstractMapper
      * @param int $keyInName key of string part in name field after exploder(' ', $value)
      * @return string|null
      */
-    private function getNameValue($rawData, $field, $keyInName)
+    private function getNameValue(mixed $rawData, string $field, int $keyInName): ?string
     {
         $value = Hash::get($rawData, $this->_mapFields[$field]);
         if ($value === null) {

--- a/src/Social/Mapper/Facebook.php
+++ b/src/Social/Mapper/Facebook.php
@@ -28,7 +28,7 @@ class Facebook extends AbstractMapper
      *
      * @var array
      */
-    protected $_mapFields = [
+    protected array $_mapFields = [
         'full_name' => 'name',
     ];
 
@@ -38,7 +38,7 @@ class Facebook extends AbstractMapper
      * @param mixed $rawData raw data
      * @return string
      */
-    protected function _avatar($rawData)
+    protected function _avatar(mixed $rawData): string
     {
         return self::FB_GRAPH_BASE_URL . ($rawData['id'] ?? '') . '/picture?type=large';
     }
@@ -49,7 +49,7 @@ class Facebook extends AbstractMapper
      * @param mixed $rawData raw data
      * @return string
      */
-    protected function _link($rawData)
+    protected function _link(mixed $rawData): string
     {
         return $rawData['link'] ?? null ?: '#';
     }

--- a/src/Social/Mapper/Google.php
+++ b/src/Social/Mapper/Google.php
@@ -25,7 +25,7 @@ class Google extends AbstractMapper
      *
      * @var array
      */
-    protected $_mapFields = [
+    protected array $_mapFields = [
         'id' => 'sub',
         'avatar' => 'picture',
         'full_name' => 'name',
@@ -42,7 +42,7 @@ class Google extends AbstractMapper
      * @param mixed $rawData raw data
      * @return string
      */
-    protected function _link($rawData)
+    protected function _link(mixed $rawData): string
     {
         return Hash::get($rawData, $this->_mapFields['link']) ?: '#';
     }

--- a/src/Social/Mapper/Instagram.php
+++ b/src/Social/Mapper/Instagram.php
@@ -30,7 +30,7 @@ class Instagram extends AbstractMapper
      *
      * @var array
      */
-    protected $_mapFields = [
+    protected array $_mapFields = [
         'full_name' => 'full_name',
         'avatar' => 'profile_picture',
     ];
@@ -41,7 +41,7 @@ class Instagram extends AbstractMapper
      * @param mixed $rawData raw data
      * @return string
      */
-    protected function _link($rawData)
+    protected function _link(mixed $rawData): string
     {
         return self::INSTAGRAM_BASE_URL . Hash::get($rawData, $this->_mapFields['username']);
     }

--- a/src/Social/Mapper/LinkedIn.php
+++ b/src/Social/Mapper/LinkedIn.php
@@ -20,7 +20,7 @@ class LinkedIn extends AbstractMapper
      *
      * @var array
      */
-    protected $_mapFields = [
+    protected array $_mapFields = [
         'avatar' => 'pictureUrl',
         'first_name' => 'firstName',
         'last_name' => 'lastName',

--- a/src/Social/Mapper/Pinterest.php
+++ b/src/Social/Mapper/Pinterest.php
@@ -20,7 +20,7 @@ class Pinterest extends AbstractMapper
      *
      * @var array
      */
-    protected $_mapFields = [
+    protected array $_mapFields = [
         'avatar' => 'image.60x60.url',
         'link' => 'url',
     ];

--- a/src/Social/Mapper/Tumblr.php
+++ b/src/Social/Mapper/Tumblr.php
@@ -23,7 +23,7 @@ class Tumblr extends AbstractMapper
      *
      * @var array
      */
-    protected $_mapFields = [
+    protected array $_mapFields = [
         'id' => 'uid',
         'username' => 'nickname',
         'full_name' => 'name',
@@ -42,7 +42,7 @@ class Tumblr extends AbstractMapper
      * @param mixed $rawData raw data
      * @return string
      */
-    protected function _id($rawData)
+    protected function _id(mixed $rawData): string
     {
         return (string)crc32($rawData['nickname']);
     }

--- a/src/Social/Mapper/Twitter.php
+++ b/src/Social/Mapper/Twitter.php
@@ -30,7 +30,7 @@ class Twitter extends AbstractMapper
      *
      * @var array
      */
-    protected $_mapFields = [
+    protected array $_mapFields = [
         'id' => 'uid',
         'username' => 'nickname',
         'full_name' => 'name',
@@ -48,7 +48,7 @@ class Twitter extends AbstractMapper
      * @param mixed $rawData raw data
      * @return string
      */
-    protected function _link($rawData)
+    protected function _link(mixed $rawData): string
     {
         return self::TWITTER_BASE_URL . Hash::get($rawData, $this->_mapFields['username']);
     }
@@ -59,7 +59,7 @@ class Twitter extends AbstractMapper
      * @param mixed $rawData raw data
      * @return string
      */
-    protected function _avatar($rawData)
+    protected function _avatar(mixed $rawData): string
     {
         return str_replace('normal', 'bigger', Hash::get($rawData, $this->_mapFields['avatar']));
     }

--- a/src/Social/ProviderConfig.php
+++ b/src/Social/ProviderConfig.php
@@ -23,14 +23,14 @@ class ProviderConfig
     /**
      * @var array
      */
-    protected $providers;
+    protected array $providers;
 
     /**
      * ProviderConfig constructor.
      *
      * @param array $config additional data
      */
-    public function __construct($config = [])
+    public function __construct(array $config = [])
     {
         $oauthConfig = Configure::read('OAuth');
 
@@ -52,7 +52,7 @@ class ProviderConfig
      * @return array
      * @throws \Exception
      */
-    public function normalizeConfig(array $config)
+    public function normalizeConfig(array $config): array
     {
         if (!empty($config['providers'])) {
             array_walk($config['providers'], [$this, '_normalizeConfig'], $config);
@@ -69,7 +69,7 @@ class ProviderConfig
      * @param array $parent Parent configuration.
      * @return void
      */
-    protected function _normalizeConfig(&$config, $alias, $parent)
+    protected function _normalizeConfig(array &$config, string $alias, array $parent): void
     {
         unset($parent['providers']);
 
@@ -107,7 +107,7 @@ class ProviderConfig
      * @throws \CakeDC\Auth\Exception\InvalidProviderException
      * @throws \CakeDC\Auth\Exception\InvalidSettingsException
      */
-    protected function _validateConfig(&$value, $key)
+    protected function _validateConfig(mixed &$value, string $key): void
     {
         if (in_array($key, ['className', 'service', 'mapper'], true) && !is_object($value) && !class_exists($value)) {
             throw new InvalidProviderException([$value]);
@@ -122,7 +122,7 @@ class ProviderConfig
      * @param array $options array of options by provider
      * @return bool
      */
-    protected function _isProviderEnabled($options)
+    protected function _isProviderEnabled(array $options): bool
     {
         return !empty($options['options']['redirectUri']) && !empty($options['options']['clientId']) &&
             !empty($options['options']['clientSecret']);
@@ -134,7 +134,7 @@ class ProviderConfig
      * @param string $alias for provider
      * @return array
      */
-    public function getConfig($alias)
+    public function getConfig(string $alias): array
     {
         return Hash::get($this->providers, $alias, []);
     }

--- a/src/Social/Service/OAuth1Service.php
+++ b/src/Social/Service/OAuth1Service.php
@@ -15,6 +15,7 @@ namespace CakeDC\Auth\Social\Service;
 
 use BadMethodCallException;
 use Cake\Http\ServerRequest;
+use CakeDC\Auth\Exception\InvalidProviderException;
 use League\OAuth1\Client\Server\Server;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -124,8 +125,11 @@ class OAuth1Service extends OAuthServiceAbstract
             $this->provider = $config['className'];
         } else {
             $class = $config['className'];
-
-            $this->provider = new $class($config['options'], $config['signature']);
+            $provider = new $class($config['options'], $config['signature']);
+            if (!is_subclass_of($provider, Server::class)) {
+                throw new InvalidProviderException([$class]);
+            }
+            $this->provider = $provider;
         }
     }
 }

--- a/src/Social/Service/OAuth1Service.php
+++ b/src/Social/Service/OAuth1Service.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CakeDC\Auth\Social\Service;
 
+use BadMethodCallException;
 use Cake\Http\ServerRequest;
 use League\OAuth1\Client\Server\Server;
 use Psr\Http\Message\ServerRequestInterface;
@@ -22,7 +23,7 @@ class OAuth1Service extends OAuthServiceAbstract
     /**
      * @var \League\OAuth1\Client\Server\Server
      */
-    protected $provider;
+    protected Server $provider;
 
     /**
      * OAuth2Service constructor.
@@ -57,7 +58,7 @@ class OAuth1Service extends OAuthServiceAbstract
     public function isGetUserStep(ServerRequestInterface $request): bool
     {
         if (!$request instanceof ServerRequest) {
-            throw new \BadMethodCallException('Request must be an instance of ServerRequest');
+            throw new BadMethodCallException('Request must be an instance of ServerRequest');
         }
         $oauthToken = $request->getQuery('oauth_token');
         $oauthVerifier = $request->getQuery('oauth_verifier');
@@ -71,10 +72,10 @@ class OAuth1Service extends OAuthServiceAbstract
      * @param \Psr\Http\Message\ServerRequestInterface $request Request object.
      * @return string
      */
-    public function getAuthorizationUrl(ServerRequestInterface $request)
+    public function getAuthorizationUrl(ServerRequestInterface $request): string
     {
         if (!$request instanceof ServerRequest) {
-            throw new \BadMethodCallException('Request must be an instance of ServerRequest');
+            throw new BadMethodCallException('Request must be an instance of ServerRequest');
         }
         $temporaryCredentials = $this->provider->getTemporaryCredentials();
         $request->getSession()->write('temporary_credentials', $temporaryCredentials);
@@ -91,7 +92,7 @@ class OAuth1Service extends OAuthServiceAbstract
     public function getUser(ServerRequestInterface $request): array
     {
         if (!$request instanceof ServerRequest) {
-            throw new \BadMethodCallException('Request must be an instance of ServerRequest');
+            throw new BadMethodCallException('Request must be an instance of ServerRequest');
         }
         $oauthToken = $request->getQuery('oauth_token');
         $oauthVerifier = $request->getQuery('oauth_verifier');
@@ -117,7 +118,7 @@ class OAuth1Service extends OAuthServiceAbstract
      * @param array $config for provider.
      * @return void
      */
-    protected function setProvider($config)
+    protected function setProvider(array $config): void
     {
         if (is_object($config['className']) && $config['className'] instanceof Server) {
             $this->provider = $config['className'];

--- a/src/Social/Service/OAuth2Service.php
+++ b/src/Social/Service/OAuth2Service.php
@@ -16,6 +16,7 @@ namespace CakeDC\Auth\Social\Service;
 use BadMethodCallException;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\ServerRequest;
+use CakeDC\Auth\Exception\InvalidProviderException;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -137,8 +138,11 @@ class OAuth2Service extends OAuthServiceAbstract
             $this->provider = $config['className'];
         } else {
             $class = $config['className'];
-
-            $this->provider = new $class($config['options'], $config['collaborators']);
+            $provider = new $class($config['options'], $config['collaborators']);
+            if (!is_subclass_of($provider, AbstractProvider::class)) {
+                throw new InvalidProviderException([$class]);
+            }
+            $this->provider = $provider;
         }
     }
 }

--- a/src/Social/Service/OAuth2Service.php
+++ b/src/Social/Service/OAuth2Service.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CakeDC\Auth\Social\Service;
 
+use BadMethodCallException;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\ServerRequest;
 use League\OAuth2\Client\Provider\AbstractProvider;
@@ -23,7 +24,7 @@ class OAuth2Service extends OAuthServiceAbstract
     /**
      * @var \League\OAuth2\Client\Provider\AbstractProvider
      */
-    protected $provider;
+    protected AbstractProvider $provider;
 
     /**
      * OAuth2Service constructor.
@@ -46,7 +47,7 @@ class OAuth2Service extends OAuthServiceAbstract
     public function isGetUserStep(ServerRequestInterface $request): bool
     {
         if (!$request instanceof ServerRequest) {
-            throw new \BadMethodCallException('Request must be an instance of ServerRequest');
+            throw new BadMethodCallException('Request must be an instance of ServerRequest');
         }
 
         return !empty($request->getQuery('code'));
@@ -58,10 +59,10 @@ class OAuth2Service extends OAuthServiceAbstract
      * @param \Psr\Http\Message\ServerRequestInterface $request Request object.
      * @return string
      */
-    public function getAuthorizationUrl(ServerRequestInterface $request)
+    public function getAuthorizationUrl(ServerRequestInterface $request): string
     {
         if (!$request instanceof ServerRequest) {
-            throw new \BadMethodCallException('Request must be an instance of ServerRequest');
+            throw new BadMethodCallException('Request must be an instance of ServerRequest');
         }
         if ($this->getConfig('options.state')) {
             $request->getSession()->write('oauth2state', $this->provider->getState());
@@ -82,7 +83,7 @@ class OAuth2Service extends OAuthServiceAbstract
     public function getUser(ServerRequestInterface $request): array
     {
         if (!$request instanceof ServerRequest) {
-            throw new \BadMethodCallException('Request must be an instance of ServerRequest');
+            throw new BadMethodCallException('Request must be an instance of ServerRequest');
         }
         if (!$this->validate($request)) {
             throw new BadRequestException('Invalid OAuth2 state');
@@ -101,7 +102,7 @@ class OAuth2Service extends OAuthServiceAbstract
      * @param \Cake\Http\ServerRequest $request Request object.
      * @return bool
      */
-    protected function validate(ServerRequest $request)
+    protected function validate(ServerRequest $request): bool
     {
         if (!array_key_exists('code', $request->getQueryParams())) {
             return false;
@@ -130,7 +131,7 @@ class OAuth2Service extends OAuthServiceAbstract
      * @param array $config for provider.
      * @return void
      */
-    protected function setProvider($config)
+    protected function setProvider(array $config): void
     {
         if (is_object($config['className']) && $config['className'] instanceof AbstractProvider) {
             $this->provider = $config['className'];

--- a/src/Social/Service/OAuthServiceAbstract.php
+++ b/src/Social/Service/OAuthServiceAbstract.php
@@ -46,12 +46,12 @@ abstract class OAuthServiceAbstract implements ServiceInterface
     /**
      * Set the social provider name
      *
-     * @param string $providerName social provider
+     * @param string $name social provider
      * @return self
      */
-    public function setProviderName(string $providerName): self
+    public function setProviderName(string $name): self
     {
-        $this->providerName = $providerName;
+        $this->providerName = $name;
 
         return $this;
     }

--- a/src/Social/Service/OAuthServiceAbstract.php
+++ b/src/Social/Service/OAuthServiceAbstract.php
@@ -24,14 +24,14 @@ abstract class OAuthServiceAbstract implements ServiceInterface
      *
      * @var array
      */
-    protected $_defaultConfig = [];
+    protected array $_defaultConfig = [];
 
     /**
      * The provider name.
      *
      * @var string
      */
-    protected $providerName = '';
+    protected string $providerName = '';
 
     /**
      * Get the social provider name
@@ -49,7 +49,7 @@ abstract class OAuthServiceAbstract implements ServiceInterface
      * @param string $providerName social provider
      * @return self
      */
-    public function setProviderName(string $providerName)
+    public function setProviderName(string $providerName): self
     {
         $this->providerName = $providerName;
 

--- a/src/Social/Service/ServiceFactory.php
+++ b/src/Social/Service/ServiceFactory.php
@@ -24,7 +24,7 @@ class ServiceFactory
      *
      * @var string
      */
-    protected $redirectUriField = 'redirectUri';
+    protected string $redirectUriField = 'redirectUri';
 
     /**
      * Set the redirect uri field name
@@ -32,7 +32,7 @@ class ServiceFactory
      * @param string $redirectUriField field used for redirect uri
      * @return self
      */
-    public function setRedirectUriField(string $redirectUriField)
+    public function setRedirectUriField(string $redirectUriField): self
     {
         $this->redirectUriField = $redirectUriField;
 
@@ -45,7 +45,7 @@ class ServiceFactory
      * @param string $provider provider alias
      * @return \CakeDC\Auth\Social\Service\ServiceInterface
      */
-    public function createFromProvider($provider): ServiceInterface
+    public function createFromProvider(string $provider): ServiceInterface
     {
         $config = (new ProviderConfig())->getConfig($provider);
 
@@ -70,7 +70,7 @@ class ServiceFactory
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @return \CakeDC\Auth\Social\Service\ServiceInterface
      */
-    public function createFromRequest(ServerRequestInterface $request)
+    public function createFromRequest(ServerRequestInterface $request): ServiceInterface
     {
         $params = $request->getAttribute('params');
         $provider = $params['provider'] ?? null;

--- a/src/Social/Service/ServiceInterface.php
+++ b/src/Social/Service/ServiceInterface.php
@@ -31,7 +31,7 @@ interface ServiceInterface
      * @param \Psr\Http\Message\ServerRequestInterface $request Request object.
      * @return string
      */
-    public function getAuthorizationUrl(ServerRequestInterface $request);
+    public function getAuthorizationUrl(ServerRequestInterface $request): string;
 
     /**
      * Get a user in social provider
@@ -54,7 +54,7 @@ interface ServiceInterface
      * @param string $name set name
      * @return self
      */
-    public function setProviderName(string $name);
+    public function setProviderName(string $name): self;
 
     /**
      * Get current config
@@ -63,5 +63,5 @@ interface ServiceInterface
      * @param mixed $default The return value when the key does not exist.
      * @return mixed Config value being read.
      */
-    public function getConfig(?string $key = null, $default = null);
+    public function getConfig(?string $key = null, mixed $default = null): mixed;
 }

--- a/src/Test/BaseTestTrait.php
+++ b/src/Test/BaseTestTrait.php
@@ -15,7 +15,7 @@ trait BaseTestTrait
      * @param string $id User id to login.
      * @return void
      */
-    public function loginAsUserId($id)
+    public function loginAsUserId(string $id): void
     {
         $data = TableRegistry::getTableLocator()
             ->get(Configure::read('Users.table', 'Users'))->get($id)->toArray();
@@ -28,7 +28,7 @@ trait BaseTestTrait
      * @param string $username Username to login.
      * @return void
      */
-    public function loginAsUserName($username)
+    public function loginAsUserName(string $username): void
     {
         $data = TableRegistry::getTableLocator()
             ->get(Configure::read('Users.table', 'Users'))->findByUsername($username)->first()->toArray();
@@ -38,7 +38,7 @@ trait BaseTestTrait
     /**
      * @return bool
      */
-    protected function _isVerboseOrDebug()
+    protected function _isVerboseOrDebug(): bool
     {
         return !empty(array_intersect(['--debug', '--verbose', '-v'], $_SERVER['argv']));
     }
@@ -54,7 +54,7 @@ trait BaseTestTrait
      * @param string $responseContains Text the response should contains.
      * @throws \PHPUnit\Exception
      */
-    protected function _testPermissions($url, $username, $method, $ajax, $responseCode, $responseContains)
+    protected function _testPermissions(string $url, string $username, string $method, string $ajax, string $responseCode, string $responseContains): void
     {
         if ($this->_isVerboseOrDebug()) {
             (new ConsoleIo())->info(__(
@@ -98,7 +98,7 @@ trait BaseTestTrait
      * @return array
      * @dataProvider provider
      */
-    public function testPermissions($csv)
+    public function testPermissions(string $csv): array
     {
         $this->assertTrue(file_exists(TESTS . 'Provider' . DS . $csv));
         $rows = array_map('str_getcsv', file(TESTS . 'Provider' . DS . $csv));

--- a/src/Traits/IsAuthorizedTrait.php
+++ b/src/Traits/IsAuthorizedTrait.php
@@ -16,7 +16,7 @@ namespace CakeDC\Auth\Traits;
 use Authorization\AuthorizationServiceInterface;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
-use Zend\Diactoros\Uri;
+use Laminas\Diactoros\Uri;
 
 trait IsAuthorizedTrait
 {

--- a/src/Traits/IsAuthorizedTrait.php
+++ b/src/Traits/IsAuthorizedTrait.php
@@ -17,17 +17,18 @@ use Authorization\AuthorizationServiceInterface;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Laminas\Diactoros\Uri;
+use RuntimeException;
 
 trait IsAuthorizedTrait
 {
     /**
      * Returns true if the target url is authorized for the logged in user
      *
-     * @param string|array|null $url url that the user is making request.
+     * @param array|string|null $url url that the user is making request.
      * @param string $action Authorization action.
      * @return bool
      */
-    public function isAuthorized($url = null, $action = 'access')
+    public function isAuthorized(string|array|null $url = null, string $action = 'access'): bool
     {
         if (empty($url)) {
             return false;
@@ -47,7 +48,7 @@ trait IsAuthorizedTrait
      * @param string $action Authorization action.
      * @return bool
      */
-    protected function _checkCanAccess($url, $action)
+    protected function _checkCanAccess(string $url, string $action): bool
     {
         /**
          * @var \Cake\Http\ServerRequest $request
@@ -55,7 +56,7 @@ trait IsAuthorizedTrait
         $request = $this->getRequest();
         $service = $request->getAttribute('authorization');
         if (!$service instanceof AuthorizationServiceInterface) {
-            throw new \RuntimeException(__('Could not find the authorization service in the request.'));
+            throw new RuntimeException(__('Could not find the authorization service in the request.'));
         }
         $identity = $request->getAttribute('identity');
         $targetRequest = $this->_createUrlRequestToCheck($url);
@@ -69,7 +70,7 @@ trait IsAuthorizedTrait
      * @param string $url The target url.
      * @return \Cake\Http\ServerRequest
      */
-    protected function _createUrlRequestToCheck($url)
+    protected function _createUrlRequestToCheck(string $url): ServerRequest
     {
         $uri = new Uri($url);
         $targetRequest = new ServerRequest([

--- a/src/Traits/ReCaptchaTrait.php
+++ b/src/Traits/ReCaptchaTrait.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace CakeDC\Auth\Traits;
 
+use BadMethodCallException;
 use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Psr\Http\Message\ServerRequestInterface;
+use ReCaptcha\ReCaptcha;
 
 /**
  * Help reCaptacha usage
@@ -28,10 +30,10 @@ trait ReCaptchaTrait
      * @param \Psr\Http\Message\ServerRequestInterface $request The request that contains login information.
      * @return bool
      */
-    public function validateReCaptchaFromRequest(ServerRequestInterface $request)
+    public function validateReCaptchaFromRequest(ServerRequestInterface $request): bool
     {
         if (!$request instanceof ServerRequest) {
-            throw new \BadMethodCallException('Request must be an instance of ServerRequest');
+            throw new BadMethodCallException('Request must be an instance of ServerRequest');
         }
         $data = $request->getParsedBody();
         $captcha = $data['g-recaptcha-response'] ?? null;
@@ -49,7 +51,7 @@ trait ReCaptchaTrait
      * @param string $clientIp client ip
      * @return bool
      */
-    public function validateReCaptcha($recaptchaResponse, $clientIp)
+    public function validateReCaptcha(string $recaptchaResponse, string $clientIp): bool
     {
         $recaptcha = $this->_getReCaptchaInstance();
         if (!empty($recaptcha)) {
@@ -66,11 +68,11 @@ trait ReCaptchaTrait
      *
      * @return \ReCaptcha\ReCaptcha|null
      */
-    protected function _getReCaptchaInstance()
+    protected function _getReCaptchaInstance(): ?ReCaptcha
     {
         $reCaptchaSecret = Configure::read('Users.reCaptcha.secret');
         if (!empty($reCaptchaSecret)) {
-            return new \ReCaptcha\ReCaptcha($reCaptchaSecret);
+            return new ReCaptcha($reCaptchaSecret);
         }
 
         return null;

--- a/tests/App/Auth/Rule/SampleRule.php
+++ b/tests/App/Auth/Rule/SampleRule.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CakeDC\Auth\Test\App\Auth\Rule;
 
+use ArrayAccess;
 use CakeDC\Auth\Rbac\Rules\AbstractRule;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -21,7 +22,7 @@ class SampleRule extends AbstractRule
     /**
      * @inheritDoc
      */
-    public function allowed($user, $role, ServerRequestInterface $request)
+    public function allowed(array|ArrayAccess $user, string $role, ServerRequestInterface $request): bool
     {
         return true;
     }

--- a/tests/App/Model/Entity/User.php
+++ b/tests/App/Model/Entity/User.php
@@ -26,7 +26,7 @@ class User extends Entity
      *
      * @var array
      */
-    protected $_accessible = [
+    protected array $_accessible = [
         '*' => true,
         'id' => false,
         'is_superuser' => false,
@@ -38,7 +38,7 @@ class User extends Entity
      *
      * @var array
      */
-    protected $_hidden = [
+    protected array $_hidden = [
         'password',
         'token',
         'token_expires',

--- a/tests/Fixture/PostsFixture.php
+++ b/tests/Fixture/PostsFixture.php
@@ -19,31 +19,9 @@ use Cake\TestSuite\Fixture\TestFixture;
 class PostsFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        'title' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'user_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Records
-     *
-     * @var array
      */
-    public $records = [
+    public array $records = [
         [
             'id' => '00000000-0000-0000-0000-000000000001',
             'title' => 'post-1',

--- a/tests/Fixture/PostsUsersFixture.php
+++ b/tests/Fixture/PostsUsersFixture.php
@@ -19,31 +19,9 @@ use Cake\TestSuite\Fixture\TestFixture;
 class PostsUsersFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        'user_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'post_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Records
-     *
-     * @var array
      */
-    public $records = [
+    public array $records = [
         [
             'id' => '00000000-0000-0000-0000-000000000011',
             'user_id' => '00000000-0000-0000-0000-000000000001',

--- a/tests/Fixture/SocialAccountsFixture.php
+++ b/tests/Fixture/SocialAccountsFixture.php
@@ -19,42 +19,9 @@ use Cake\TestSuite\Fixture\TestFixture;
 class SocialAccountsFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        'user_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'provider' => ['type' => 'string', 'length' => 255, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
-        'username' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'reference' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'avatar' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'description' => ['type' => 'text', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
-        'token' => ['type' => 'string', 'length' => 500, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'token_secret' => ['type' => 'string', 'length' => 500, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'token_expires' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
-        'active' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => true, 'comment' => '', 'precision' => null],
-        'data' => ['type' => 'text', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Records
-     *
-     * @var array
      */
-    public $records = [
+    public array $records = [
         [
             'id' => '00000000-0000-0000-0000-000000000001',
             'user_id' => '00000000-0000-0000-0000-000000000001',

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -19,46 +19,9 @@ use Cake\TestSuite\Fixture\TestFixture;
 class UsersFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        'username' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'email' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'password' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'first_name' => ['type' => 'string', 'length' => 50, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'last_name' => ['type' => 'string', 'length' => 50, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'token' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'token_expires' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
-        'api_token' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'activation_date' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
-        'secret' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'secret_verified' => ['type' => 'boolean', 'length' => null, 'null' => true, 'default' => false, 'comment' => '', 'precision' => null],
-        'tos_date' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
-        'active' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => true, 'comment' => '', 'precision' => null],
-        'is_superuser' => ['type' => 'boolean', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => false, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
-        'role' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => 'user', 'comment' => '', 'precision' => null, 'fixed' => null],
-        'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-
-    /**
      * Records
-     *
-     * @var array
      */
-    public $records = [
+    public array $records = [
         [
             'id' => '00000000-0000-0000-0000-000000000001',
             'username' => 'user-1',

--- a/tests/TestApplication.php
+++ b/tests/TestApplication.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
  */
 namespace CakeDC\Auth\Test;
 
+use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
 
 /**
@@ -19,7 +20,7 @@ use Cake\Http\MiddlewareQueue;
  *
  * @package CakeDC\Auth\Test
  */
-class TestApplication extends \Cake\Http\BaseApplication
+class TestApplication extends BaseApplication
 {
     /**
      * Setup the middleware queue

--- a/tests/TestCase/Auth/Rbac/PermissionMatchResultTest.php
+++ b/tests/TestCase/Auth/Rbac/PermissionMatchResultTest.php
@@ -18,10 +18,7 @@ use CakeDC\Auth\Rbac\PermissionMatchResult;
 
 class PermissionMatchResultTest extends TestCase
 {
-    /**
-     * @var PermissionMatchResult
-     */
-    protected $permissionMatchResult;
+    protected PermissionMatchResult $permissionMatchResult;
 
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/tests/TestCase/Authentication/AuthenticationServiceTest.php
+++ b/tests/TestCase/Authentication/AuthenticationServiceTest.php
@@ -263,6 +263,7 @@ class AuthenticationServiceTest extends TestCase
         $actual = $service->getFailures();
         $this->assertEquals($expected, $actual);
     }
+
     /**
      * testAuthenticate
      *

--- a/tests/TestCase/Authentication/AuthenticationServiceTest.php
+++ b/tests/TestCase/Authentication/AuthenticationServiceTest.php
@@ -21,15 +21,12 @@ use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Authentication\AuthenticationService;
 use CakeDC\Auth\Authentication\Failure;
 use CakeDC\Auth\Authenticator\FormAuthenticator;
+use CakeDC\Auth\Test\App\Model\Entity\User;
+use RuntimeException;
 
 class AuthenticationServiceTest extends TestCase
 {
-    /**
-     * Fixtures
-     *
-     * @var array
-     */
-    public $fixtures = [
+    public array $fixtures = [
         'plugin.CakeDC/Auth.Users',
         'plugin.CakeDC/Auth.SocialAccounts',
     ];
@@ -54,7 +51,7 @@ class AuthenticationServiceTest extends TestCase
             ],
             'authenticators' => [],
         ]);
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No authenticators loaded. You need to load at least one authenticator.');
         $service->authenticate($request);
     }
@@ -67,7 +64,7 @@ class AuthenticationServiceTest extends TestCase
     public function testAuthenticateFail()
     {
         $Table = TableRegistry::getTableLocator()->get('CakeDC/Auth.Users');
-        $Table->setEntityClass(\CakeDC\Auth\Test\App\Model\Entity\User::class);
+        $Table->setEntityClass(User::class);
         $entity = $Table->get('00000000-0000-0000-0000-000000000001');
         $entity->password = 'password';
         $this->assertTrue((bool)$Table->save($entity));
@@ -120,7 +117,7 @@ class AuthenticationServiceTest extends TestCase
         Configure::write('OneTimePasswordAuthenticator.login', false);
         Configure::write('U2f.enabled', false);
         $Table = TableRegistry::getTableLocator()->get('CakeDC/Auth.Users');
-        $Table->setEntityClass(\CakeDC\Auth\Test\App\Model\Entity\User::class);
+        $Table->setEntityClass(User::class);
         $entity = $Table->get('00000000-0000-0000-0000-000000000001');
         $entity->password = 'password';
         $this->assertTrue((bool)$Table->save($entity));
@@ -169,7 +166,7 @@ class AuthenticationServiceTest extends TestCase
         Configure::write('OneTimePasswordAuthenticator.login', true);
         Configure::write('U2f.enabled', false);
         $Table = TableRegistry::getTableLocator()->get('CakeDC/Auth.Users');
-        $Table->setEntityClass(\CakeDC\Auth\Test\App\Model\Entity\User::class);
+        $Table->setEntityClass(User::class);
         $entity = $Table->get('00000000-0000-0000-0000-000000000001');
         $entity->password = 'password';
         $this->assertTrue((bool)$Table->save($entity));
@@ -221,7 +218,7 @@ class AuthenticationServiceTest extends TestCase
         Configure::write('U2f.enabled', false);
         Configure::write('OneTimePasswordAuthenticator.login', false);
         $Table = TableRegistry::getTableLocator()->get('CakeDC/Auth.Users');
-        $Table->setEntityClass(\CakeDC\Auth\Test\App\Model\Entity\User::class);
+        $Table->setEntityClass(User::class);
         $entity = $Table->get('00000000-0000-0000-0000-000000000001');
         $entity->password = 'password';
         $this->assertTrue((bool)$Table->save($entity));
@@ -273,7 +270,7 @@ class AuthenticationServiceTest extends TestCase
     {
         Configure::write('Webauthn2fa.enabled', true);
         $Table = TableRegistry::getTableLocator()->get('CakeDC/Auth.Users');
-        $Table->setEntityClass(\CakeDC\Auth\Test\App\Model\Entity\User::class);
+        $Table->setEntityClass(User::class);
         $entity = $Table->get('00000000-0000-0000-0000-000000000001');
         $entity->password = 'password';
         $this->assertTrue((bool)$Table->save($entity));
@@ -325,7 +322,7 @@ class AuthenticationServiceTest extends TestCase
     {
         Configure::write('U2f.enabled', true);
         $Table = TableRegistry::getTableLocator()->get('CakeDC/Auth.Users');
-        $Table->setEntityClass(\CakeDC\Auth\Test\App\Model\Entity\User::class);
+        $Table->setEntityClass(User::class);
         $entity = $Table->get('00000000-0000-0000-0000-000000000001');
         $entity->password = 'password';
         $this->assertTrue((bool)$Table->save($entity));
@@ -377,7 +374,7 @@ class AuthenticationServiceTest extends TestCase
     {
         Configure::write('U2f.enabled', false);
         $Table = TableRegistry::getTableLocator()->get('CakeDC/Auth.Users');
-        $Table->setEntityClass(\CakeDC\Auth\Test\App\Model\Entity\User::class);
+        $Table->setEntityClass(User::class);
         $entity = $Table->get('00000000-0000-0000-0000-000000000001');
         $entity->password = 'password';
         $this->assertTrue((bool)$Table->save($entity));

--- a/tests/TestCase/Authentication/DefaultWebauthn2fAuthenticationCheckerTest.php
+++ b/tests/TestCase/Authentication/DefaultWebauthn2fAuthenticationCheckerTest.php
@@ -14,7 +14,7 @@ namespace CakeDC\Users\Test\TestCase\Authentication;
 
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
-use CakeDC\Auth\Authentication\DefaultWebauthn2fAuthenticationChecker;
+use CakeDC\Auth\Authentication\DefaultWebauthn2FAuthenticationChecker;
 
 /**
  * Test case for DefaultWebauthn2fAuthenticationChecker class
@@ -31,15 +31,15 @@ class DefaultWebauthn2fAuthenticationCheckerTest extends TestCase
     public function testIsEnabled()
     {
         Configure::write('Webauthn2fa.enabled', false);
-        $Checker = new DefaultWebauthn2fAuthenticationChecker();
+        $Checker = new DefaultWebauthn2FAuthenticationChecker();
         $this->assertFalse($Checker->isEnabled());
 
         Configure::write('Webauthn2fa.enabled', true);
-        $Checker = new DefaultWebauthn2fAuthenticationChecker();
+        $Checker = new DefaultWebauthn2FAuthenticationChecker();
         $this->assertTrue($Checker->isEnabled());
 
         Configure::delete('Webauthn2fa.enabled');
-        $Checker = new DefaultWebauthn2fAuthenticationChecker();
+        $Checker = new DefaultWebauthn2FAuthenticationChecker();
         $this->assertTrue($Checker->isEnabled());
     }
 
@@ -51,18 +51,18 @@ class DefaultWebauthn2fAuthenticationCheckerTest extends TestCase
     public function testIsRequired()
     {
         Configure::write('Webauthn2fa.enabled', false);
-        $Checker = new DefaultWebauthn2fAuthenticationChecker();
+        $Checker = new DefaultWebauthn2FAuthenticationChecker();
         $this->assertFalse($Checker->isRequired(['id' => 10]));
 
         Configure::write('Webauthn2fa.enabled', true);
-        $Checker = new DefaultWebauthn2fAuthenticationChecker();
+        $Checker = new DefaultWebauthn2FAuthenticationChecker();
         $this->assertTrue($Checker->isRequired(['id' => 10]));
 
         Configure::delete('Webauthn2fa.enabled');
-        $Checker = new DefaultWebauthn2fAuthenticationChecker();
+        $Checker = new DefaultWebauthn2FAuthenticationChecker();
         $this->assertTrue($Checker->isRequired(['id' => 10]));
 
-        $Checker = new DefaultWebauthn2fAuthenticationChecker();
+        $Checker = new DefaultWebauthn2FAuthenticationChecker();
         $this->assertFalse($Checker->isRequired([]));
     }
 }

--- a/tests/TestCase/Authentication/OneTimePasswordAuthenticationCheckerFactoryTest.php
+++ b/tests/TestCase/Authentication/OneTimePasswordAuthenticationCheckerFactoryTest.php
@@ -16,6 +16,8 @@ use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Authentication\DefaultOneTimePasswordAuthenticationChecker;
 use CakeDC\Auth\Authentication\OneTimePasswordAuthenticationCheckerFactory;
+use InvalidArgumentException;
+use stdClass;
 
 class OneTimePasswordAuthenticationCheckerFactoryTest extends TestCase
 {
@@ -37,8 +39,8 @@ class OneTimePasswordAuthenticationCheckerFactoryTest extends TestCase
      */
     public function testGetCheckerInvalidInterface()
     {
-        Configure::write('OneTimePasswordAuthenticator.checker', \stdClass::class);
-        $this->expectException(\InvalidArgumentException::class);
+        Configure::write('OneTimePasswordAuthenticator.checker', stdClass::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Invalid config for 'OneTimePasswordAuthenticator.checker', 'stdClass' does not implement 'CakeDC\Auth\Authentication\OneTimePasswordAuthenticationCheckerInterface'");
         (new OneTimePasswordAuthenticationCheckerFactory())->build();
     }

--- a/tests/TestCase/Authentication/U2fAuthenticationCheckerFactoryTest.php
+++ b/tests/TestCase/Authentication/U2fAuthenticationCheckerFactoryTest.php
@@ -16,6 +16,8 @@ use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Authentication\DefaultU2fAuthenticationChecker;
 use CakeDC\Auth\Authentication\U2fAuthenticationCheckerFactory;
+use InvalidArgumentException;
+use stdClass;
 
 class U2fAuthenticationCheckerFactoryTest extends TestCase
 {
@@ -37,8 +39,8 @@ class U2fAuthenticationCheckerFactoryTest extends TestCase
      */
     public function testGetCheckerInvalidInterface()
     {
-        Configure::write('U2f.checker', \stdClass::class);
-        $this->expectException(\InvalidArgumentException::class);
+        Configure::write('U2f.checker', stdClass::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Invalid config for 'U2f.checker', 'stdClass' does not implement 'CakeDC\Auth\Authentication\U2fAuthenticationCheckerInterface'");
         (new U2fAuthenticationCheckerFactory())->build();
     }

--- a/tests/TestCase/Authentication/Webauthn2fAuthenticationCheckerFactoryTest.php
+++ b/tests/TestCase/Authentication/Webauthn2fAuthenticationCheckerFactoryTest.php
@@ -14,8 +14,10 @@ namespace CakeDC\Auth\Test\TestCase\Authentication;
 
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
-use CakeDC\Auth\Authentication\DefaultWebauthn2fAuthenticationChecker;
+use CakeDC\Auth\Authentication\DefaultWebauthn2FAuthenticationChecker;
 use CakeDC\Auth\Authentication\Webauthn2fAuthenticationCheckerFactory;
+use InvalidArgumentException;
+use stdClass;
 
 class Webauthn2fAuthenticationCheckerFactoryTest extends TestCase
 {
@@ -27,7 +29,7 @@ class Webauthn2fAuthenticationCheckerFactoryTest extends TestCase
     public function testGetChecker()
     {
         $result = (new Webauthn2fAuthenticationCheckerFactory())->build();
-        $this->assertInstanceOf(DefaultWebauthn2fAuthenticationChecker::class, $result);
+        $this->assertInstanceOf(DefaultWebauthn2FAuthenticationChecker::class, $result);
     }
 
     /**
@@ -37,9 +39,9 @@ class Webauthn2fAuthenticationCheckerFactoryTest extends TestCase
      */
     public function testGetCheckerInvalidInterface()
     {
-        Configure::write('Webauthn2fa.checker', \stdClass::class);
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage("Invalid config for 'Webauthn2fa.checker', 'stdClass' does not implement 'CakeDC\Auth\Authentication\Webauthn2FAuthenticationCheckerInterface'");
+        Configure::write('Webauthn2fa.checker', stdClass::class);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid config for 'Webauthn2fa.checker', 'stdClass' does not implement 'CakeDC\Auth\Authentication\Webauthn2fAuthenticationCheckerInterface'");
         (new Webauthn2fAuthenticationCheckerFactory())->build();
     }
 }

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -16,6 +16,7 @@ use ArrayObject;
 use Authentication\Identifier\IdentifierCollection;
 use Cake\Http\Response;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Security;
 use CakeDC\Auth\Authenticator\CookieAuthenticator;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -71,6 +72,7 @@ class CookieAuthenticatorTest extends TestCase
             'username' => 'johndoe',
             'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO',
         ]);
+        Security::setSalt('22f40226f5b51926aeb29995ebf0108eae3435e2');
         $result = $authenticator->persistIdentity($request, $response, $identity);
         $this->assertIsArray($result);
         $this->assertArrayHasKey('request', $result);

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -56,7 +56,7 @@ class CookieAuthenticatorTest extends TestCase
         $identifiers = new IdentifierCollection([
             'Authentication.Password',
         ]);
-        $uri = new \Zend\Diactoros\Uri('/login');
+        $uri = new \Laminas\Diactoros\Uri('/login');
         $uri->base = null;
         $request = new \Cake\Http\ServerRequest();
         $request = $request->withUri($uri);

--- a/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/CookieAuthenticatorTest.php
@@ -15,9 +15,11 @@ namespace CakeDC\Auth\Test\TestCase\Authenticator;
 use ArrayObject;
 use Authentication\Identifier\IdentifierCollection;
 use Cake\Http\Response;
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use CakeDC\Auth\Authenticator\CookieAuthenticator;
+use Laminas\Diactoros\Uri;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -56,9 +58,9 @@ class CookieAuthenticatorTest extends TestCase
         $identifiers = new IdentifierCollection([
             'Authentication.Password',
         ]);
-        $uri = new \Laminas\Diactoros\Uri('/login');
+        $uri = new Uri('/login');
         $uri->base = null;
-        $request = new \Cake\Http\ServerRequest();
+        $request = new ServerRequest();
         $request = $request->withUri($uri);
 
         $request = $request->withParsedBody($post);

--- a/tests/TestCase/Authenticator/FormAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/FormAuthenticatorTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
  */
 namespace CakeDC\Auth\Test\TestCase\Authenticator;
 
+use Authentication\Authenticator\FormAuthenticator as CakeFormAuthenticator;
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
 use Authentication\Identifier\IdentifierInterface;
@@ -34,7 +35,7 @@ class FormAuthenticatorTest extends TestCase
             'Authentication.Password',
         ]);
 
-        $BaseAuthenticator = $this->getMockBuilder(\Authentication\Authenticator\FormAuthenticator::class)
+        $BaseAuthenticator = $this->getMockBuilder(CakeFormAuthenticator::class)
             ->setConstructorArgs([$identifiers])
             ->setMethods(['authenticate'])
             ->getMock();
@@ -98,7 +99,7 @@ class FormAuthenticatorTest extends TestCase
             'Authentication.Password',
         ]);
 
-        $BaseAuthenticator = $this->getMockBuilder(\Authentication\Authenticator\FormAuthenticator::class)
+        $BaseAuthenticator = $this->getMockBuilder(CakeFormAuthenticator::class)
             ->setConstructorArgs([$identifiers])
             ->setMethods(['authenticate'])
             ->getMock();
@@ -171,7 +172,7 @@ class FormAuthenticatorTest extends TestCase
             'Authentication.Password',
         ]);
 
-        $BaseAuthenticator = $this->getMockBuilder(\Authentication\Authenticator\FormAuthenticator::class)
+        $BaseAuthenticator = $this->getMockBuilder(CakeFormAuthenticator::class)
             ->setConstructorArgs([$identifiers])
             ->setMethods(['authenticate'])
             ->getMock();
@@ -238,7 +239,7 @@ class FormAuthenticatorTest extends TestCase
             'Authentication.Password',
         ]);
 
-        $BaseAuthenticator = $this->getMockBuilder(\Authentication\Authenticator\FormAuthenticator::class)
+        $BaseAuthenticator = $this->getMockBuilder(CakeFormAuthenticator::class)
             ->setConstructorArgs([$identifiers])
             ->setMethods(['authenticate'])
             ->getMock();
@@ -320,7 +321,7 @@ class FormAuthenticatorTest extends TestCase
             ]
         );
         $actual = $Authenticator->getBaseAuthenticator();
-        $this->assertInstanceOf(\Authentication\Authenticator\FormAuthenticator::class, $actual);
+        $this->assertInstanceOf(CakeFormAuthenticator::class, $actual);
         $this->assertNotInstanceOf(FormAuthenticator::class, $actual);
         $expected = [
             'fields' => [
@@ -352,11 +353,11 @@ class FormAuthenticatorTest extends TestCase
                     IdentifierInterface::CREDENTIAL_PASSWORD => 'password',
                 ],
                 'keyCheckEnabledRecaptcha' => 'Users.reCaptcha.login',
-                'baseClassName' => \Authentication\Authenticator\FormAuthenticator::class,
+                'baseClassName' => CakeFormAuthenticator::class,
             ]
         );
         $actual = $Authenticator->getBaseAuthenticator();
-        $this->assertInstanceOf(\Authentication\Authenticator\FormAuthenticator::class, $actual);
+        $this->assertInstanceOf(CakeFormAuthenticator::class, $actual);
         $this->assertNotInstanceOf(FormAuthenticator::class, $actual);
         $expected = [
             'fields' => [

--- a/tests/TestCase/Authenticator/SocialAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/SocialAuthenticatorTest.php
@@ -20,8 +20,8 @@ use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Authenticator\SocialAuthenticator;
 use CakeDC\Auth\Social\Service\ServiceFactory;
+use Laminas\Diactoros\Uri;
 use League\OAuth2\Client\Provider\FacebookUser;
-use Zend\Diactoros\Uri;
 
 /**
  * Test Case for SocialAuthenticator class

--- a/tests/TestCase/Authenticator/TwoFactorAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TwoFactorAuthenticatorTest.php
@@ -27,7 +27,7 @@ class TwoFactorAuthenticatorTest extends TestCase
      */
     public function testAuthenticateFailedNoData()
     {
-        $uri = new \Zend\Diactoros\Uri('/testpath');
+        $uri = new \Laminas\Diactoros\Uri('/testpath');
         $uri->base = null;
         $request = new \Cake\Http\ServerRequest();
         $request = $request->withUri($uri);
@@ -51,7 +51,7 @@ class TwoFactorAuthenticatorTest extends TestCase
      */
     public function testAuthenticateFailedInvalidUrl()
     {
-        $uri = new \Zend\Diactoros\Uri('/testpath');
+        $uri = new \Laminas\Diactoros\Uri('/testpath');
         $uri->base = null;
         $request = new \Cake\Http\ServerRequest();
         $request = $request->withUri($uri);
@@ -82,7 +82,7 @@ class TwoFactorAuthenticatorTest extends TestCase
      */
     public function testAuthenticate()
     {
-        $uri = new \Zend\Diactoros\Uri('/testpath');
+        $uri = new \Laminas\Diactoros\Uri('/testpath');
         $uri->base = null;
         $request = new \Cake\Http\ServerRequest();
         $request = $request->withUri($uri);

--- a/tests/TestCase/Authenticator/TwoFactorAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/TwoFactorAuthenticatorTest.php
@@ -14,9 +14,11 @@ namespace CakeDC\Auth\Test\TestCase\Authenticator;
 
 use Authentication\Authenticator\Result;
 use Authentication\Identifier\IdentifierCollection;
+use Cake\Http\ServerRequest;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Authenticator\TwoFactorAuthenticator;
+use Laminas\Diactoros\Uri;
 
 class TwoFactorAuthenticatorTest extends TestCase
 {
@@ -27,9 +29,9 @@ class TwoFactorAuthenticatorTest extends TestCase
      */
     public function testAuthenticateFailedNoData()
     {
-        $uri = new \Laminas\Diactoros\Uri('/testpath');
+        $uri = new Uri('/testpath');
         $uri->base = null;
-        $request = new \Cake\Http\ServerRequest();
+        $request = new ServerRequest();
         $request = $request->withUri($uri);
         $identifiers = new IdentifierCollection([
             'Authentication.Password',
@@ -51,9 +53,9 @@ class TwoFactorAuthenticatorTest extends TestCase
      */
     public function testAuthenticateFailedInvalidUrl()
     {
-        $uri = new \Laminas\Diactoros\Uri('/testpath');
+        $uri = new Uri('/testpath');
         $uri->base = null;
-        $request = new \Cake\Http\ServerRequest();
+        $request = new ServerRequest();
         $request = $request->withUri($uri);
         $request->getSession()->write(
             TwoFactorAuthenticator::USER_SESSION_KEY,
@@ -82,9 +84,9 @@ class TwoFactorAuthenticatorTest extends TestCase
      */
     public function testAuthenticate()
     {
-        $uri = new \Laminas\Diactoros\Uri('/testpath');
+        $uri = new Uri('/testpath');
         $uri->base = null;
-        $request = new \Cake\Http\ServerRequest();
+        $request = new ServerRequest();
         $request = $request->withUri($uri);
         $request->getSession()->write(
             TwoFactorAuthenticator::USER_SESSION_KEY,

--- a/tests/TestCase/Controller/Component/OneTimePasswordAuthenticatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/OneTimePasswordAuthenticatorComponentTest.php
@@ -60,12 +60,13 @@ class OneTimePasswordAuthenticatorComponentTest extends TestCase
         $this->backupUsersConfig = Configure::read('Users');
 
         Router::reload();
-        Router::createRouteBuilder('/')->connect('/route/*', [
+        $builder = Router::createRouteBuilder('/');
+        $builder->connect('/route/*', [
             'plugin' => 'CakeDC/Users',
             'controller' => 'Users',
             'action' => 'requestResetPassword',
         ]);
-        Router::createRouteBuilder('/')->connect('/notAllowed/*', [
+        $builder->connect('/notAllowed/*', [
             'plugin' => 'CakeDC/Users',
             'controller' => 'Users',
             'action' => 'edit',

--- a/tests/TestCase/Controller/Component/OneTimePasswordAuthenticatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/OneTimePasswordAuthenticatorComponentTest.php
@@ -15,6 +15,7 @@ namespace CakeDC\Users\Test\TestCase\Controller\Component;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
@@ -33,11 +34,6 @@ class OneTimePasswordAuthenticatorComponentTest extends TestCase
     public $request;
 
     /**
-     * @var \Cake\Http\Response&\PHPUnit\Framework\MockObject\MockObject|mixed
-     */
-    public $response;
-
-    /**
      * @var \Cake\Controller\Controller|mixed
      */
     public $Controller;
@@ -49,7 +45,7 @@ class OneTimePasswordAuthenticatorComponentTest extends TestCase
 
     public $OneTimePasswordAuthenticator;
 
-    public $fixtures = [
+    public array $fixtures = [
         'plugin.CakeDC/Auth.Users',
     ];
 
@@ -64,12 +60,12 @@ class OneTimePasswordAuthenticatorComponentTest extends TestCase
         $this->backupUsersConfig = Configure::read('Users');
 
         Router::reload();
-        Router::connect('/route/*', [
+        Router::createRouteBuilder('/')->connect('/route/*', [
             'plugin' => 'CakeDC/Users',
             'controller' => 'Users',
             'action' => 'requestResetPassword',
         ]);
-        Router::connect('/notAllowed/*', [
+        Router::createRouteBuilder('/')->connect('/notAllowed/*', [
             'plugin' => 'CakeDC/Users',
             'controller' => 'Users',
             'action' => 'edit',
@@ -79,14 +75,11 @@ class OneTimePasswordAuthenticatorComponentTest extends TestCase
         Configure::write('App.namespace', 'Users');
         Configure::write('OneTimePasswordAuthenticator.login', true);
 
-        $this->request = $this->getMockBuilder(\Cake\Http\ServerRequest::class)
+        $this->request = $this->getMockBuilder(ServerRequest::class)
                 ->setMethods(['is', 'method'])
                 ->getMock();
         $this->request->expects($this->any())->method('is')->will($this->returnValue(true));
-        $this->response = $this->getMockBuilder(\Cake\Http\Response::class)
-                ->setMethods(['stop'])
-                ->getMock();
-        $this->Controller = new Controller($this->request, $this->response);
+        $this->Controller = new Controller($this->request);
         $this->Registry = $this->Controller->components();
         $this->Controller->OneTimePasswordAuthenticator = new OneTimePasswordAuthenticatorComponent($this->Registry);
     }
@@ -112,7 +105,7 @@ class OneTimePasswordAuthenticatorComponentTest extends TestCase
     public function testInitialize()
     {
         $this->Controller->OneTimePasswordAuthenticator = new OneTimePasswordAuthenticatorComponent($this->Registry);
-        $this->assertInstanceOf(\CakeDC\Auth\Controller\Component\OneTimePasswordAuthenticatorComponent::class, $this->Controller->OneTimePasswordAuthenticator);
+        $this->assertInstanceOf(OneTimePasswordAuthenticatorComponent::class, $this->Controller->OneTimePasswordAuthenticator);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/OneTimePasswordAuthenticatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/OneTimePasswordAuthenticatorComponentTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CakeDC\Users\Test\TestCase\Controller\Component;
 
+use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
@@ -20,30 +21,15 @@ use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use CakeDC\Auth\Controller\Component\OneTimePasswordAuthenticatorComponent;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class OneTimePasswordAuthenticatorComponentTest extends TestCase
 {
-    /**
-     * @var mixed
-     */
-    public $backupUsersConfig;
+    public mixed $backupUsersConfig;
 
-    /**
-     * @var \Cake\Http\ServerRequest&\PHPUnit\Framework\MockObject\MockObject|mixed
-     */
-    public $request;
-
-    /**
-     * @var \Cake\Controller\Controller|mixed
-     */
-    public $Controller;
-
-    /**
-     * @var \Cake\Controller\ComponentRegistry|mixed
-     */
-    public $Registry;
-
-    public $OneTimePasswordAuthenticator;
+    public MockObject|ServerRequest $request;
+    public Controller $Controller;
+    public ComponentRegistry $Registry;
 
     public array $fixtures = [
         'plugin.CakeDC/Auth.Users',
@@ -95,7 +81,7 @@ class OneTimePasswordAuthenticatorComponentTest extends TestCase
         parent::tearDown();
 
         $_SESSION = [];
-        unset($this->Controller, $this->OneTimePasswordAuthenticator);
+        unset($this->Controller);
         Configure::write('Users', $this->backupUsersConfig);
         Configure::write('OneTimePasswordAuthenticator.login', false);
     }

--- a/tests/TestCase/Exception/InvalidProviderExceptionTest.php
+++ b/tests/TestCase/Exception/InvalidProviderExceptionTest.php
@@ -18,24 +18,8 @@ use CakeDC\Auth\Exception\InvalidProviderException;
 
 class InvalidProviderExceptionTest extends TestCase
 {
-    protected $_messageTemplate = 'Invalid provider or missing class (%s)';
-    protected $code = 500;
-
-    /**
-     * Setup
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    /**
-     * Tear Down
-     */
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
+    protected string $_messageTemplate = 'Invalid provider or missing class (%s)';
+    protected int $code = 500;
 
     /**
      * Test construct

--- a/tests/TestCase/Exception/InvalidSettingsExceptionTest.php
+++ b/tests/TestCase/Exception/InvalidSettingsExceptionTest.php
@@ -18,24 +18,8 @@ use CakeDC\Auth\Exception\InvalidSettingsException;
 
 class InvalidSettingsExceptionTest extends TestCase
 {
-    protected $_messageTemplate = 'Invalid settings for key (%s)';
-    protected $code = 500;
-
-    /**
-     * Setup
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    /**
-     * Tear Down
-     */
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
+    protected string $_messageTemplate = 'Invalid settings for key (%s)';
+    protected int $code = 500;
 
     /**
      * Test construct

--- a/tests/TestCase/Identifier/SocialIdentifierTest.php
+++ b/tests/TestCase/Identifier/SocialIdentifierTest.php
@@ -12,13 +12,15 @@ declare(strict_types=1);
  */
 namespace CakeDC\Auth\Test\TestCase\Identifier;
 
+use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Identifier\SocialIdentifier;
 use CakeDC\Auth\Social\Mapper\Facebook;
+use League\OAuth2\Client\Token\AccessToken;
 
 class SocialIdentifierTest extends TestCase
 {
-    public $fixtures = [
+    public array $fixtures = [
         'plugin.CakeDC/Auth.Users',
         'plugin.CakeDC/Auth.SocialAccounts',
     ];
@@ -54,7 +56,7 @@ class SocialIdentifierTest extends TestCase
             'resolver' => 'Authentication.ORM',
         ]);
 
-        $Token = new \League\OAuth2\Client\Token\AccessToken([
+        $Token = new AccessToken([
             'access_token' => 'test-token',
             'expires' => 1490988496,
         ]);
@@ -98,7 +100,7 @@ class SocialIdentifierTest extends TestCase
         $user['provider'] = 'facebook';
 
         $result = $identifier->identify(['socialAuthUser' => $user]);
-        $this->assertInstanceOf(\Cake\ORM\Entity::class, $result);
+        $this->assertInstanceOf(Entity::class, $result);
         $this->assertEquals($result->id, '00000000-0000-0000-0000-000000000001');
         $this->assertEquals('user-1@test.com', $result->email);
         $this->assertEquals('user-1', $result->username);
@@ -111,7 +113,7 @@ class SocialIdentifierTest extends TestCase
      */
     public function testIdentifyErrorSocialLogin()
     {
-        $Token = new \League\OAuth2\Client\Token\AccessToken([
+        $Token = new AccessToken([
             'access_token' => 'test-token',
             'expires' => 1490988496,
         ]);
@@ -157,7 +159,7 @@ class SocialIdentifierTest extends TestCase
      */
     public function testIdentifyNoEmail()
     {
-        $Token = new \League\OAuth2\Client\Token\AccessToken([
+        $Token = new AccessToken([
             'access_token' => 'test-token',
             'expires' => 1490988496,
         ]);

--- a/tests/TestCase/Middleware/RbacMiddlewareTest.php
+++ b/tests/TestCase/Middleware/RbacMiddlewareTest.php
@@ -29,10 +29,7 @@ use CakeDC\Auth\Rbac\Rbac;
  */
 class RbacMiddlewareTest extends TestCase
 {
-    /**
-     * @var RbacMiddleware
-     */
-    protected $rbacMiddleware;
+    protected RbacMiddleware $rbacMiddleware;
 
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/tests/TestCase/Middleware/RbacMiddlewareTest.php
+++ b/tests/TestCase/Middleware/RbacMiddlewareTest.php
@@ -99,7 +99,7 @@ class RbacMiddlewareTest extends TestCase
     {
         $request = new ServerRequest();
         $rbacMiddleware = $this->rbacMiddleware;
-        Router::connect('/login', [
+        Router::createRouteBuilder('/')->connect('/login', [
             'controller' => 'Users',
             'action' => 'login',
         ]);

--- a/tests/TestCase/Middleware/SocialAuthMiddlewareTest.php
+++ b/tests/TestCase/Middleware/SocialAuthMiddlewareTest.php
@@ -16,30 +16,26 @@ namespace CakeDC\Auth\Test\TestCase\Middleware;
 use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\Runner;
+use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Middleware\SocialAuthMiddleware;
+use CakeDC\Auth\Social\Mapper\Facebook as FacebookMapper;
 use CakeDC\Auth\Social\Service\OAuth2Service;
 use Laminas\Diactoros\Uri;
+use League\OAuth2\Client\Provider\Facebook;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class SocialAuthMiddlewareTest extends TestCase
 {
-    public $fixtures = [
+    public array $fixtures = [
         'plugin.CakeDC/Auth.Users',
         'plugin.CakeDC/Auth.SocialAccounts',
     ];
 
-    /**
-     * @var \League\OAuth2\Client\Provider\Facebook
-     */
-    public $Provider;
-
-    /**
-     * @var \Cake\Http\ServerRequest
-     */
-    public $Request;
+    public Facebook $Provider;
+    public ServerRequest $Request;
 
     /**
      * Setup the test case, backup the static object values so they can be restored.
@@ -52,7 +48,7 @@ class SocialAuthMiddlewareTest extends TestCase
     {
         parent::setUp();
 
-        $this->Provider = $this->getMockBuilder(\League\OAuth2\Client\Provider\Facebook::class)->setConstructorArgs([
+        $this->Provider = $this->getMockBuilder(Facebook::class)->setConstructorArgs([
             [
                 'graphApiVersion' => 'v2.8',
                 'redirectUri' => '/auth/facebook',
@@ -67,9 +63,9 @@ class SocialAuthMiddlewareTest extends TestCase
         ])->getMock();
 
         $config = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth2Service::class,
+            'service' => OAuth2Service::class,
             'className' => $this->Provider,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Facebook::class,
+            'mapper' => FacebookMapper::class,
             'options' => [
                 'state' => '__TEST_STATE__',
                 'graphApiVersion' => 'v2.8',
@@ -115,6 +111,7 @@ class SocialAuthMiddlewareTest extends TestCase
     {
         $uri = new Uri('/auth/facebook');
         $this->Request = $this->Request->withUri($uri);
+        $this->Request = $this->Request->withAttribute('base', '');
 
         $this->Request = $this->Request->withAttribute('params', [
             'plugin' => 'CakeDC/Auth',
@@ -162,6 +159,7 @@ class SocialAuthMiddlewareTest extends TestCase
     {
         $uri = new Uri('/auth/facebook');
         $this->Request = $this->Request->withUri($uri);
+        $this->Request = $this->Request->withAttribute('base', '');
         $this->Request = $this->Request->withQueryParams([
             'code' => 'ZPO9972j3092304230',
             'state' => '__TEST_STATE__',

--- a/tests/TestCase/Middleware/SocialAuthMiddlewareTest.php
+++ b/tests/TestCase/Middleware/SocialAuthMiddlewareTest.php
@@ -20,9 +20,9 @@ use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Middleware\SocialAuthMiddleware;
 use CakeDC\Auth\Social\Service\OAuth2Service;
+use Laminas\Diactoros\Uri;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Diactoros\Uri;
 
 class SocialAuthMiddlewareTest extends TestCase
 {

--- a/tests/TestCase/Middleware/TwoFactorMiddlewareTest.php
+++ b/tests/TestCase/Middleware/TwoFactorMiddlewareTest.php
@@ -31,10 +31,7 @@ use CakeDC\Auth\Middleware\TwoFactorMiddleware;
  */
 class TwoFactorMiddlewareTest extends TestCase
 {
-    /**
-     * @var TwoFactorMiddleware
-     */
-    protected $TwoFactorMiddleware;
+    protected TwoFactorMiddleware $TwoFactorMiddleware;
 
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/tests/TestCase/Middleware/TwoFactorMiddlewareTest.php
+++ b/tests/TestCase/Middleware/TwoFactorMiddlewareTest.php
@@ -110,7 +110,7 @@ class TwoFactorMiddlewareTest extends TestCase
             'controller' => 'Users',
             'action' => 'verify',
         ]);
-        Router::connect('/verify', [
+        Router::createRouteBuilder('/')->connect('/verify', [
             'controller' => 'Users',
             'action' => 'verify',
         ]);

--- a/tests/TestCase/Policy/RbacPolicyTest.php
+++ b/tests/TestCase/Policy/RbacPolicyTest.php
@@ -19,7 +19,9 @@ use Cake\Http\ServerRequestFactory;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Policy\RbacPolicy;
+use CakeDC\Auth\Rbac\Permissions\ConfigProvider;
 use CakeDC\Auth\Rbac\Rbac;
+use InvalidArgumentException;
 
 class RbacPolicyTest extends TestCase
 {
@@ -137,7 +139,7 @@ class RbacPolicyTest extends TestCase
             'autoload_config' => 'my_permissions',
             'role_field' => 'group',
             'default_role' => 'user',
-            'permissions_provider_class' => \CakeDC\Auth\Rbac\Permissions\ConfigProvider::class,
+            'permissions_provider_class' => ConfigProvider::class,
             'permissions' => null,
             'log' => true,
         ];
@@ -175,7 +177,7 @@ class RbacPolicyTest extends TestCase
         $request = ServerRequestFactory::fromGlobals();
         $policy = new RbacPolicy([]);
         $policy->setConfig('adapter', [], false);
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Config "adapter" should be an object or an array with key className');
         $policy->getRbac($request);
     }

--- a/tests/TestCase/Rbac/Permissions/ConfigProviderTest.php
+++ b/tests/TestCase/Rbac/Permissions/ConfigProviderTest.php
@@ -18,15 +18,10 @@ use CakeDC\Auth\Rbac\Permissions\ConfigProvider;
 
 /**
  * ConfigProviderTest
- *
- * @property ConfigProvider configProvider
  */
 class ConfigProviderTest extends TestCase
 {
-    /**
-     * @var \CakeDC\Auth\Rbac\Permissions\ConfigProvider|mixed
-     */
-    public $configProvider;
+    protected ConfigProvider $configProvider;
 
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/tests/TestCase/Rbac/RbacTest.php
+++ b/tests/TestCase/Rbac/RbacTest.php
@@ -18,6 +18,7 @@ use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Rbac\Rbac;
 use CakeDC\Auth\Rbac\Rules\Owner;
 use CakeDC\Auth\Test\App\Auth\Rule\SampleRule;
+use Exception;
 use Psr\Log\LogLevel;
 use ReflectionClass;
 use RuntimeException;
@@ -39,7 +40,6 @@ class RbacTest extends TestCase
      */
     public function setUp(): void
     {
-        $request = new ServerRequest();
         $this->defaultPermissions = [
             //all bypass
             [
@@ -106,7 +106,7 @@ class RbacTest extends TestCase
                 'action' => 'display',
             ],
         ];
-        $this->rbac = new Rbac(null, $this->defaultPermissions);
+        $this->rbac = new Rbac($this->defaultPermissions);
     }
 
     /**
@@ -194,7 +194,7 @@ class RbacTest extends TestCase
                         'controller' => 'Tests',
                         'action' => 'three', // Discard here
                         function () {
-                            throw new \Exception();
+                            throw new Exception();
                         },
                     ],
                     [
@@ -233,7 +233,7 @@ class RbacTest extends TestCase
                     [
                         // This permission isn't evaluated
                         function () {
-                            throw new \Exception();
+                            throw new Exception();
                         },
                         'plugin' => ['Tests'],
                         'role' => ['test'],
@@ -340,7 +340,7 @@ class RbacTest extends TestCase
                     [
                         'allowed' => false,
                         function () {
-                            throw new \Exception();
+                            throw new Exception();
                         },
                         'controller' => 'Tests',
                         'action' => 'one',

--- a/tests/TestCase/Rbac/Rules/OwnerTest.php
+++ b/tests/TestCase/Rbac/Rules/OwnerTest.php
@@ -26,16 +26,11 @@ use RuntimeException;
  */
 class OwnerTest extends TestCase
 {
-    /**
-     * @var \CakeDC\Auth\Rbac\Rules\Owner|mixed
-     */
-    public $Owner;
-    /**
-     * @var \Cake\Http\ServerRequest|mixed
-     */
-    public $request;
+    public Owner $Owner;
 
-    public $fixtures = [
+    public ServerRequest $request;
+
+    public array $fixtures = [
         'plugin.CakeDC/Auth.Posts',
         'plugin.CakeDC/Auth.Users',
         'plugin.CakeDC/Auth.PostsUsers',
@@ -47,6 +42,8 @@ class OwnerTest extends TestCase
      */
     public function setUp(): void
     {
+        parent::setUp();
+
         $this->Owner = new Owner();
         $this->request = new ServerRequest();
     }
@@ -57,6 +54,7 @@ class OwnerTest extends TestCase
      */
     public function tearDown(): void
     {
+        parent::tearDown();
         unset($this->Owner);
     }
 

--- a/tests/TestCase/Rbac/Rules/OwnerTest.php
+++ b/tests/TestCase/Rbac/Rules/OwnerTest.php
@@ -20,15 +20,10 @@ use CakeDC\Auth\Rbac\Rules\Owner;
 use OutOfBoundsException;
 use RuntimeException;
 
-/**
- * @property Owner Owner
- * @property ServerRequest request
- */
 class OwnerTest extends TestCase
 {
-    public Owner $Owner;
-
-    public ServerRequest $request;
+    protected Owner $Owner;
+    protected ServerRequest $request;
 
     public array $fixtures = [
         'plugin.CakeDC/Auth.Posts',

--- a/tests/TestCase/Rbac/Rules/RuleRegistryTest.php
+++ b/tests/TestCase/Rbac/Rules/RuleRegistryTest.php
@@ -17,10 +17,6 @@ use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Rbac\Rules\Owner;
 use CakeDC\Auth\Rbac\Rules\RuleRegistry;
 
-/**
- * @property Owner Owner
- * @property ServerRequest request
- */
 class RuleRegistryTest extends TestCase
 {
     /**

--- a/tests/TestCase/Social/MapUserTest.php
+++ b/tests/TestCase/Social/MapUserTest.php
@@ -27,6 +27,7 @@ class MapUserTest extends TestCase
      * @var \\League\OAuth2\Client\Provider\Facebook&\PHPUnit\Framework\MockObject\MockObject|mixed
      */
     public $Provider;
+
     /**
      * Setup the test case, backup the static object values so they can be restored.
      * Specifically backs up the contents of Configure and paths in App if they have

--- a/tests/TestCase/Social/MapUserTest.php
+++ b/tests/TestCase/Social/MapUserTest.php
@@ -15,16 +15,19 @@ namespace CakeDC\Auth\Test\TestCase\Social;
 
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
+use CakeDC\Auth\Social\Mapper\Facebook as FacebookMapper;
 use CakeDC\Auth\Social\MapUser;
 use CakeDC\Auth\Social\Service\OAuth2Service;
 use CakeDC\Auth\Social\Service\ServiceFactory;
+use InvalidArgumentException;
 use League\OAuth2\Client\Provider\Facebook;
 use League\OAuth2\Client\Provider\FacebookUser;
+use League\OAuth2\Client\Token\AccessToken;
 
 class MapUserTest extends TestCase
 {
     /**
-     * @var \\League\OAuth2\Client\Provider\Facebook&\PHPUnit\Framework\MockObject\MockObject|mixed
+     * @var \League\OAuth2\Client\Provider\Facebook&\PHPUnit\Framework\MockObject\MockObject|mixed
      */
     public $Provider;
 
@@ -39,7 +42,7 @@ class MapUserTest extends TestCase
     {
         parent::setUp();
 
-        $this->Provider = $this->getMockBuilder(\League\OAuth2\Client\Provider\Facebook::class)->setConstructorArgs([
+        $this->Provider = $this->getMockBuilder(Facebook::class)->setConstructorArgs([
             [
                 'graphApiVersion' => 'v2.8',
                 'redirectUri' => '/auth/facebook',
@@ -54,9 +57,9 @@ class MapUserTest extends TestCase
         ])->getMock();
 
         $config = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth2Service::class,
+            'service' => OAuth2Service::class,
             'className' => $this->Provider,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Facebook::class,
+            'mapper' => FacebookMapper::class,
             'options' => [
                 'state' => '__TEST_STATE__',
                 'graphApiVersion' => 'v2.8',
@@ -86,7 +89,7 @@ class MapUserTest extends TestCase
     {
         $service = (new ServiceFactory())->createFromProvider('facebook');
 
-        $Token = new \League\OAuth2\Client\Token\AccessToken([
+        $Token = new AccessToken([
             'access_token' => 'test-token',
             'expires' => 1490988496,
         ]);
@@ -180,7 +183,7 @@ class MapUserTest extends TestCase
         ]);
 
         $mapper = new MapUser();
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Provider mapper class CakeDC\Auth\Social\Mapper\NotExisting does not exist');
         $mapper($service, $user);
     }

--- a/tests/TestCase/Social/MapUserTest.php
+++ b/tests/TestCase/Social/MapUserTest.php
@@ -23,13 +23,11 @@ use InvalidArgumentException;
 use League\OAuth2\Client\Provider\Facebook;
 use League\OAuth2\Client\Provider\FacebookUser;
 use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class MapUserTest extends TestCase
 {
-    /**
-     * @var \League\OAuth2\Client\Provider\Facebook&\PHPUnit\Framework\MockObject\MockObject|mixed
-     */
-    public $Provider;
+    public MockObject|Facebook $Provider;
 
     /**
      * Setup the test case, backup the static object values so they can be restored.

--- a/tests/TestCase/Social/Mapper/CognitoTest.php
+++ b/tests/TestCase/Social/Mapper/CognitoTest.php
@@ -15,6 +15,7 @@ namespace CakeDC\Auth\Test\TestCase\Social\Mapper;
 
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Social\Mapper\Cognito;
+use League\OAuth2\Client\Token\AccessToken;
 
 /**
  * Class CognitoTest
@@ -25,7 +26,7 @@ class CognitoTest extends TestCase
 {
     public function testMap()
     {
-        $token = new \League\OAuth2\Client\Token\AccessToken([
+        $token = new AccessToken([
             'access_token' => 'test-token',
             'expires' => 1490988496,
         ]);

--- a/tests/TestCase/Social/Mapper/FacebookTest.php
+++ b/tests/TestCase/Social/Mapper/FacebookTest.php
@@ -15,6 +15,7 @@ namespace CakeDC\Auth\Test\TestCase\Social\Mapper;
 
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Social\Mapper\Facebook;
+use League\OAuth2\Client\Token\AccessToken;
 
 class FacebookTest extends TestCase
 {
@@ -30,7 +31,7 @@ class FacebookTest extends TestCase
 
     public function testMap()
     {
-        $token = new \League\OAuth2\Client\Token\AccessToken([
+        $token = new AccessToken([
             'access_token' => 'test-token',
             'expires' => 1490988496,
         ]);

--- a/tests/TestCase/Social/Mapper/FacebookTest.php
+++ b/tests/TestCase/Social/Mapper/FacebookTest.php
@@ -19,16 +19,6 @@ use League\OAuth2\Client\Token\AccessToken;
 
 class FacebookTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     public function testMap()
     {
         $token = new AccessToken([

--- a/tests/TestCase/Social/Mapper/GoogleTest.php
+++ b/tests/TestCase/Social/Mapper/GoogleTest.php
@@ -19,16 +19,6 @@ use League\OAuth2\Client\Token\AccessToken;
 
 class GoogleTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     public function testMap()
     {
         $token = new AccessToken([

--- a/tests/TestCase/Social/Mapper/GoogleTest.php
+++ b/tests/TestCase/Social/Mapper/GoogleTest.php
@@ -15,6 +15,7 @@ namespace CakeDC\Auth\Test\TestCase\Social\Mapper;
 
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Social\Mapper\Google;
+use League\OAuth2\Client\Token\AccessToken;
 
 class GoogleTest extends TestCase
 {
@@ -30,7 +31,7 @@ class GoogleTest extends TestCase
 
     public function testMap()
     {
-        $token = new \League\OAuth2\Client\Token\AccessToken([
+        $token = new AccessToken([
             'access_token' => 'test-token',
             'expires' => 1490988496,
         ]);

--- a/tests/TestCase/Social/Mapper/InstagramTest.php
+++ b/tests/TestCase/Social/Mapper/InstagramTest.php
@@ -15,6 +15,7 @@ namespace CakeDC\Auth\Test\TestCase\Social\Mapper;
 
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Social\Mapper\Instagram;
+use League\OAuth2\Client\Token\AccessToken;
 
 class InstagramTest extends TestCase
 {
@@ -30,7 +31,7 @@ class InstagramTest extends TestCase
 
     public function testMap()
     {
-        $token = new \League\OAuth2\Client\Token\AccessToken([
+        $token = new AccessToken([
             'access_token' => 'test-token',
             'expires' => 1490988496,
         ]);

--- a/tests/TestCase/Social/Mapper/InstagramTest.php
+++ b/tests/TestCase/Social/Mapper/InstagramTest.php
@@ -19,16 +19,6 @@ use League\OAuth2\Client\Token\AccessToken;
 
 class InstagramTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     public function testMap()
     {
         $token = new AccessToken([

--- a/tests/TestCase/Social/Mapper/LinkedInTest.php
+++ b/tests/TestCase/Social/Mapper/LinkedInTest.php
@@ -19,16 +19,6 @@ use League\OAuth2\Client\Token\AccessToken;
 
 class LinkedInTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     public function testMap()
     {
         $token = new AccessToken([

--- a/tests/TestCase/Social/Mapper/LinkedInTest.php
+++ b/tests/TestCase/Social/Mapper/LinkedInTest.php
@@ -15,6 +15,7 @@ namespace CakeDC\Auth\Test\TestCase\Social\Mapper;
 
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Social\Mapper\LinkedIn;
+use League\OAuth2\Client\Token\AccessToken;
 
 class LinkedInTest extends TestCase
 {
@@ -30,7 +31,7 @@ class LinkedInTest extends TestCase
 
     public function testMap()
     {
-        $token = new \League\OAuth2\Client\Token\AccessToken([
+        $token = new AccessToken([
             'access_token' => 'test-token',
             'expires' => 1490988496,
         ]);

--- a/tests/TestCase/Social/Mapper/TwitterTest.php
+++ b/tests/TestCase/Social/Mapper/TwitterTest.php
@@ -18,16 +18,6 @@ use CakeDC\Auth\Social\Mapper\Twitter;
 
 class TwitterTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     public function testMap()
     {
         $rawData = [

--- a/tests/TestCase/Social/ProviderConfigTest.php
+++ b/tests/TestCase/Social/ProviderConfigTest.php
@@ -17,7 +17,15 @@ use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Exception\InvalidProviderException;
 use CakeDC\Auth\Exception\InvalidSettingsException;
+use CakeDC\Auth\Social\Mapper\Amazon as AmazonMapper;
+use CakeDC\Auth\Social\Mapper\Facebook as FacebookMapper;
+use CakeDC\Auth\Social\Mapper\Twitter as TwitterMapper;
 use CakeDC\Auth\Social\ProviderConfig;
+use CakeDC\Auth\Social\Service\OAuth1Service;
+use CakeDC\Auth\Social\Service\OAuth2Service;
+use League\OAuth1\Client\Server\Twitter;
+use League\OAuth2\Client\Provider\Facebook;
+use Luchianenco\OAuth2\Client\Provider\Amazon;
 
 /**
  * Users\Social\ProviderConfig Test Case
@@ -86,9 +94,9 @@ class ProviderConfigTest extends TestCase
             ],
             'providers' => [
                 'facebook' => [
-                    'service' => \CakeDC\Auth\Social\Service\OAuth2Service::class,
-                    'className' => \League\OAuth2\Client\Provider\Facebook::class,
-                    'mapper' => \CakeDC\Auth\Social\Mapper\Facebook::class,
+                    'service' => OAuth2Service::class,
+                    'className' => Facebook::class,
+                    'mapper' => FacebookMapper::class,
                     'options' => 'invalid options',
                 ],
             ],
@@ -131,9 +139,9 @@ class ProviderConfigTest extends TestCase
             ],
         ]);
         $expected = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth2Service::class,
-            'className' => \League\OAuth2\Client\Provider\Facebook::class,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Facebook::class,
+            'service' => OAuth2Service::class,
+            'className' => Facebook::class,
+            'mapper' => FacebookMapper::class,
             'authParams' => ['scope' => ['public_profile', 'email', 'user_birthday', 'user_gender', 'user_link']],
             'options' => [
                 'customOption' => 'hello',
@@ -174,9 +182,9 @@ class ProviderConfigTest extends TestCase
 
         $Config = new ProviderConfig();
         $expected = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth2Service::class,
-            'className' => \League\OAuth2\Client\Provider\Facebook::class,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Facebook::class,
+            'service' => OAuth2Service::class,
+            'className' => Facebook::class,
+            'mapper' => FacebookMapper::class,
             'authParams' => ['scope' => ['public_profile', 'email', 'user_birthday', 'user_gender', 'user_link']],
             'options' => [
                 'graphApiVersion' => 'v2.8',
@@ -201,9 +209,9 @@ class ProviderConfigTest extends TestCase
         $this->assertEquals($expected, $actual);
 
         $expected = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth1Service::class,
-            'className' => \League\OAuth1\Client\Server\Twitter::class,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Twitter::class,
+            'service' => OAuth1Service::class,
+            'className' => Twitter::class,
+            'mapper' => TwitterMapper::class,
             'authParams' => [],
             'options' => [
                 'redirectUri' => 'http://localhost/auth/twitter',
@@ -226,9 +234,9 @@ class ProviderConfigTest extends TestCase
         $this->assertEquals($expected, $actual);
 
         $expected = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth2Service::class,
-            'className' => \Luchianenco\OAuth2\Client\Provider\Amazon::class,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Amazon::class,
+            'service' => OAuth2Service::class,
+            'className' => Amazon::class,
+            'mapper' => AmazonMapper::class,
             'authParams' => [],
             'options' => [
                 'redirectUri' => 'http://localhost/auth/amazon',

--- a/tests/TestCase/Social/Service/OAuth1ServiceTest.php
+++ b/tests/TestCase/Social/Service/OAuth1ServiceTest.php
@@ -131,11 +131,11 @@ class OAuth1ServiceTest extends TestCase
         $Credentials->setIdentifier('404405646989097789546879');
         $Credentials->setSecret('secretpasword');
 
-        $this->Provider->expects($this->atLeastOnce())
+        $this->Provider->expects($this->once())
             ->method('getTemporaryCredentials')
             ->will($this->returnValue($Credentials));
 
-        $this->Provider->expects($this->atLeastOnce())
+        $this->Provider->expects($this->once())
             ->method('getAuthorizationUrl')
             ->with(
                 $this->equalTo($Credentials)
@@ -311,7 +311,7 @@ class OAuth1ServiceTest extends TestCase
         $this->Provider->expects($this->never())
             ->method('getTemporaryCredentials');
 
-        $this->Provider->expects($this->atLeastOnce())
+        $this->Provider->expects($this->once())
             ->method('getTokenCredentials')
             ->with(
                 $this->equalTo($Credentials),
@@ -320,7 +320,7 @@ class OAuth1ServiceTest extends TestCase
             )
             ->will($this->returnValue($TokenCredentials));
 
-        $this->Provider->expects($this->atLeastOnce())
+        $this->Provider->expects($this->once())
             ->method('getUserDetails')
             ->with(
                 $this->equalTo($TokenCredentials)

--- a/tests/TestCase/Social/Service/OAuth1ServiceTest.php
+++ b/tests/TestCase/Social/Service/OAuth1ServiceTest.php
@@ -18,29 +18,21 @@ use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
+use CakeDC\Auth\Social\Mapper\Twitter as TwitterMapper;
 use CakeDC\Auth\Social\Service\OAuth1Service;
 use CakeDC\Auth\Social\Service\ServiceInterface;
 use Laminas\Diactoros\Uri;
 use League\OAuth1\Client\Credentials\TemporaryCredentials;
 use League\OAuth1\Client\Credentials\TokenCredentials;
+use League\OAuth1\Client\Server\Server;
+use League\OAuth1\Client\Server\Twitter;
 use League\OAuth1\Client\Server\User;
 
 class OAuth1ServiceTest extends TestCase
 {
-    /**
-     * @var \CakeDC\Auth\Social\Service\OAuth1Service
-     */
-    public $Service;
-
-    /**
-     * @var \League\OAuth1\Client\Server\Server
-     */
-    public $Provider;
-
-    /**
-     * @var \Cake\Http\ServerRequest
-     */
-    public $Request;
+    public OAuth1Service $Service;
+    public Server $Provider;
+    public ServerRequest $Request;
 
     /**
      * Setup the test case, backup the static object values so they can be restored.
@@ -53,7 +45,7 @@ class OAuth1ServiceTest extends TestCase
     {
         parent::setUp();
 
-        $this->Provider = $this->getMockBuilder(\League\OAuth1\Client\Server\Twitter::class)->setConstructorArgs([
+        $this->Provider = $this->getMockBuilder(Twitter::class)->setConstructorArgs([
             [
                 'redirectUri' => '/auth/twitter',
                 'linkSocialUri' => '/link-social/twitter',
@@ -66,9 +58,9 @@ class OAuth1ServiceTest extends TestCase
         ])->getMock();
 
         $config = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth1Service::class,
+            'service' => OAuth1Service::class,
             'className' => $this->Provider,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Twitter::class,
+            'mapper' => TwitterMapper::class,
             'options' => [],
             'collaborators' => [],
             'signature' => null,
@@ -106,8 +98,8 @@ class OAuth1ServiceTest extends TestCase
     public function testConstruct()
     {
         $service = new OAuth1Service([
-            'className' => \League\OAuth1\Client\Server\Twitter::class,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Twitter::class,
+            'className' => Twitter::class,
+            'mapper' => TwitterMapper::class,
             'options' => [
                 'redirectUri' => '/auth/twitter',
                 'linkSocialUri' => '/link-social/twitter',
@@ -139,11 +131,11 @@ class OAuth1ServiceTest extends TestCase
         $Credentials->setIdentifier('404405646989097789546879');
         $Credentials->setSecret('secretpasword');
 
-        $this->Provider->expects($this->at(0))
+        $this->Provider->expects($this->atLeastOnce())
             ->method('getTemporaryCredentials')
             ->will($this->returnValue($Credentials));
 
-        $this->Provider->expects($this->at(1))
+        $this->Provider->expects($this->atLeastOnce())
             ->method('getAuthorizationUrl')
             ->with(
                 $this->equalTo($Credentials)
@@ -319,7 +311,7 @@ class OAuth1ServiceTest extends TestCase
         $this->Provider->expects($this->never())
             ->method('getTemporaryCredentials');
 
-        $this->Provider->expects($this->at(0))
+        $this->Provider->expects($this->atLeastOnce())
             ->method('getTokenCredentials')
             ->with(
                 $this->equalTo($Credentials),
@@ -328,7 +320,7 @@ class OAuth1ServiceTest extends TestCase
             )
             ->will($this->returnValue($TokenCredentials));
 
-        $this->Provider->expects($this->at(1))
+        $this->Provider->expects($this->atLeastOnce())
             ->method('getUserDetails')
             ->with(
                 $this->equalTo($TokenCredentials)

--- a/tests/TestCase/Social/Service/OAuth1ServiceTest.php
+++ b/tests/TestCase/Social/Service/OAuth1ServiceTest.php
@@ -20,10 +20,10 @@ use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Social\Service\OAuth1Service;
 use CakeDC\Auth\Social\Service\ServiceInterface;
+use Laminas\Diactoros\Uri;
 use League\OAuth1\Client\Credentials\TemporaryCredentials;
 use League\OAuth1\Client\Credentials\TokenCredentials;
 use League\OAuth1\Client\Server\User;
-use Zend\Diactoros\Uri;
 
 class OAuth1ServiceTest extends TestCase
 {

--- a/tests/TestCase/Social/Service/OAuth2ServiceTest.php
+++ b/tests/TestCase/Social/Service/OAuth2ServiceTest.php
@@ -206,11 +206,11 @@ class OAuth2ServiceTest extends TestCase
      */
     public function testGetAuthorizationUrl()
     {
-        $this->Provider->expects($this->atLeastOnce())
+        $this->Provider->expects($this->once())
             ->method('getState')
             ->will($this->returnValue('_NEW_STATE_'));
 
-        $this->Provider->expects($this->atLeastOnce())
+        $this->Provider->expects($this->once())
             ->method('getAuthorizationUrl')
             ->with($this->equalTo([
                 'scope' => ['public_profile', 'email', 'user_birthday', 'user_gender', 'user_link'],
@@ -283,7 +283,7 @@ class OAuth2ServiceTest extends TestCase
         $this->Provider->expects($this->never())
             ->method('getState');
 
-        $this->Provider->expects($this->atLeastOnce())
+        $this->Provider->expects($this->once())
             ->method('getAccessToken')
             ->with(
                 $this->equalTo('authorization_code'),
@@ -291,7 +291,7 @@ class OAuth2ServiceTest extends TestCase
             )
             ->will($this->returnValue($Token));
 
-        $this->Provider->expects($this->atLeastOnce())
+        $this->Provider->expects($this->once())
             ->method('getResourceOwner')
             ->with(
                 $this->equalTo($Token)

--- a/tests/TestCase/Social/Service/OAuth2ServiceTest.php
+++ b/tests/TestCase/Social/Service/OAuth2ServiceTest.php
@@ -21,8 +21,8 @@ use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use CakeDC\Auth\Social\Service\OAuth2Service;
 use CakeDC\Auth\Social\Service\ServiceInterface;
+use Laminas\Diactoros\Uri;
 use League\OAuth2\Client\Provider\FacebookUser;
-use Zend\Diactoros\Uri;
 
 class OAuth2ServiceTest extends TestCase
 {

--- a/tests/TestCase/Social/Service/ServiceFactoryTest.php
+++ b/tests/TestCase/Social/Service/ServiceFactoryTest.php
@@ -17,16 +17,17 @@ use Cake\Core\Configure;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
+use CakeDC\Auth\Social\Mapper\Facebook as FacebookMapper;
+use CakeDC\Auth\Social\Mapper\Twitter as TwitterMapper;
 use CakeDC\Auth\Social\Service\OAuth1Service;
 use CakeDC\Auth\Social\Service\OAuth2Service;
 use CakeDC\Auth\Social\Service\ServiceFactory;
+use League\OAuth1\Client\Server\Twitter;
+use League\OAuth2\Client\Provider\Facebook;
 
 class ServiceFactoryTest extends TestCase
 {
-    /**
-     * @var ServiceFactory
-     */
-    public $Factory;
+    public ServiceFactory $Factory;
 
     /**
      * Setup the test case, backup the static object values so they can be restored.
@@ -50,9 +51,9 @@ class ServiceFactoryTest extends TestCase
     public function testCreateFromRequest()
     {
         $config = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth2Service::class,
-            'className' => \League\OAuth2\Client\Provider\Facebook::class,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Facebook::class,
+            'service' => OAuth2Service::class,
+            'className' => Facebook::class,
+            'mapper' => FacebookMapper::class,
             'authParams' => ['scope' => ['public_profile', 'email', 'user_birthday', 'user_gender', 'user_link']],
             'options' => [
                 'state' => '__TEST_STATE__',
@@ -92,9 +93,9 @@ class ServiceFactoryTest extends TestCase
         $this->assertEquals('facebook', $service->getProviderName());
 
         $expected = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth2Service::class,
-            'className' => \League\OAuth2\Client\Provider\Facebook::class,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Facebook::class,
+            'service' => OAuth2Service::class,
+            'className' => Facebook::class,
+            'mapper' => FacebookMapper::class,
             'authParams' => ['scope' => ['public_profile', 'email', 'user_birthday', 'user_gender', 'user_link']],
             'options' => [
                 'state' => '__TEST_STATE__',
@@ -125,9 +126,9 @@ class ServiceFactoryTest extends TestCase
     public function testCreateFromRequestCustomRedirectUriField()
     {
         $config = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth2Service::class,
-            'className' => \League\OAuth2\Client\Provider\Facebook::class,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Facebook::class,
+            'service' => OAuth2Service::class,
+            'className' => Facebook::class,
+            'mapper' => FacebookMapper::class,
             'authParams' => ['scope' => ['public_profile', 'email', 'user_birthday', 'user_gender', 'user_link']],
             'options' => [
                 'state' => '__TEST_STATE__',
@@ -168,9 +169,9 @@ class ServiceFactoryTest extends TestCase
         $this->assertEquals('facebook', $service->getProviderName());
 
         $expected = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth2Service::class,
-            'className' => \League\OAuth2\Client\Provider\Facebook::class,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Facebook::class,
+            'service' => OAuth2Service::class,
+            'className' => Facebook::class,
+            'mapper' => FacebookMapper::class,
             'authParams' => ['scope' => ['public_profile', 'email', 'user_birthday', 'user_gender', 'user_link']],
             'options' => [
                 'state' => '__TEST_STATE__',
@@ -201,9 +202,9 @@ class ServiceFactoryTest extends TestCase
     public function testCreateFromRequestOAuth1()
     {
         $config = [
-            'service' => \CakeDC\Auth\Social\Service\OAuth1Service::class,
-            'className' => \League\OAuth1\Client\Server\Twitter::class,
-            'mapper' => \CakeDC\Auth\Social\Mapper\Twitter::class,
+            'service' => OAuth1Service::class,
+            'className' => Twitter::class,
+            'mapper' => TwitterMapper::class,
             'authParams' => ['scope' => ['public_profile', 'email', 'user_birthday', 'user_gender', 'user_link']],
             'options' => [
                 'redirectUri' => '/auth/twitter',

--- a/tests/TestCase/Traits/IsAuthorizedTraitTest.php
+++ b/tests/TestCase/Traits/IsAuthorizedTraitTest.php
@@ -26,6 +26,8 @@ use CakeDC\Auth\Policy\CollectionPolicy;
 use CakeDC\Auth\Policy\RbacPolicy;
 use CakeDC\Auth\Policy\SuperuserPolicy;
 use CakeDC\Auth\Rbac\Rbac;
+use CakeDC\Auth\Traits\IsAuthorizedTrait;
+use RuntimeException;
 
 /**
  * Class IsAuthorizedTraitTest
@@ -62,7 +64,7 @@ class IsAuthorizedTraitTest extends TestCase
      */
     public function testIsAuthorizedEmpty()
     {
-        $Trait = $this->getMockBuilder(\CakeDC\Auth\Traits\IsAuthorizedTrait::class)
+        $Trait = $this->getMockBuilder(IsAuthorizedTrait::class)
             ->setMethods(['getRequest'])
             ->getMockForTrait();
         $Trait->expects($this->never())
@@ -82,7 +84,7 @@ class IsAuthorizedTraitTest extends TestCase
      */
     public function testIsAuthorizedWithMock($url, $authorize, $invalidUrl = false)
     {
-        Router::connect('/my-test', [
+        Router::createRouteBuilder('/')->connect('/my-test', [
             'plugin' => 'CakeDC/Users',
             'controller' => 'Users',
             'action' => 'myTest',
@@ -119,7 +121,7 @@ class IsAuthorizedTraitTest extends TestCase
         $request = $request->withAttribute('authorization', $service);
         $request = $request->withAttribute('identity', new IdentityDecorator($service, $identity));
 
-        $Trait = $this->getMockBuilder(\CakeDC\Auth\Traits\IsAuthorizedTrait::class)
+        $Trait = $this->getMockBuilder(IsAuthorizedTrait::class)
             ->setMethods(['getRequest'])
             ->getMockForTrait();
         $Trait->expects($this->any())
@@ -137,7 +139,7 @@ class IsAuthorizedTraitTest extends TestCase
      */
     public function testIsAuthorizedWithoutService()
     {
-        Router::connect('/my-test', [
+        Router::createRouteBuilder('/')->connect('/my-test', [
             'plugin' => 'CakeDC/Users',
             'controller' => 'Users',
             'action' => 'myTest',
@@ -148,14 +150,14 @@ class IsAuthorizedTraitTest extends TestCase
             ->method('checkPermissions');
         $request = $request->withAttribute('rbac', $rbac);
 
-        $Trait = $this->getMockBuilder(\CakeDC\Auth\Traits\IsAuthorizedTrait::class)
+        $Trait = $this->getMockBuilder(IsAuthorizedTrait::class)
             ->setMethods(['getRequest'])
             ->getMockForTrait();
         $Trait->expects($this->any())
             ->method('getRequest')
             ->will($this->returnValue($request));
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Could not find the authorization service in the request.');
         $Trait->isAuthorized([
             'plugin' => 'CakeDC/Users',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Cake\Datasource\ConnectionManager;
 use Cake\Routing\Router;
 use Cake\TestSuite\Fixture\SchemaLoader;
+use Cake\Utility\Security;
 use CakeDC\Auth\Test\TestApplication;
 
 /**
@@ -109,7 +110,7 @@ Cake\Core\Configure::write('Session', [
     'defaults' => 'php',
 ]);
 
-\Cake\Utility\Security::setSalt('yoyz186elmi66ab9pz4imbb3tgy9vnsgsfgwe2r8tyxbbfdygu9e09tlxyg8p7dq');
+Security::setSalt('yoyz186elmi66ab9pz4imbb3tgy9vnsgsfgwe2r8tyxbbfdygu9e09tlxyg8p7dq');
 
 if (!getenv('DB_URL')) {
     putenv('DB_URL=sqlite:///:memory:');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,11 @@
 <?php
 declare(strict_types=1);
 
+use Cake\Datasource\ConnectionManager;
+use Cake\Routing\Router;
+use Cake\TestSuite\Fixture\SchemaLoader;
+use CakeDC\Auth\Test\TestApplication;
+
 /**
  * Copyright 2010 - 2019, Cake Development Corporation (https://www.cakedc.com)
  *
@@ -37,17 +42,21 @@ if (!defined('DS')) {
 }
 define('ROOT', $root);
 define('APP_DIR', 'App');
+
+define('TMP', ROOT . DS . 'tmp' . DS);
+define('LOGS', TMP . 'logs' . DS);
+define('CACHE', TMP . 'cache' . DS);
+define('SESSIONS', TMP . 'sessions' . DS);
+
+define('CAKE_CORE_INCLUDE_PATH', ROOT . '/vendor/cakephp/cakephp');
+define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
+define('CAKE', CORE_PATH . 'src' . DS);
+
 define('WEBROOT_DIR', 'webroot');
 define('APP', ROOT . '/tests/App/');
 define('CONFIG', ROOT . '/tests/config/');
 define('WWW_ROOT', ROOT . DS . WEBROOT_DIR . DS);
 define('TESTS', ROOT . DS . 'tests' . DS);
-define('TMP', ROOT . DS . 'tmp' . DS);
-define('LOGS', TMP . 'logs' . DS);
-define('CACHE', TMP . 'cache' . DS);
-define('CAKE_CORE_INCLUDE_PATH', ROOT . '/vendor/cakephp/cakephp');
-define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
-define('CAKE', CORE_PATH . 'src' . DS);
 
 require ROOT . '/vendor/cakephp/cakephp/src/basics.php';
 require ROOT . '/vendor/autoload.php';
@@ -71,10 +80,9 @@ Cake\Core\Configure::write('App.encoding', 'UTF-8');
 
 ini_set('intl.default_locale', 'en_US');
 
-$TMP = new \Cake\Filesystem\Folder(TMP);
-$TMP->create(TMP . 'cache/models', 0777);
-$TMP->create(TMP . 'cache/persistent', 0777);
-$TMP->create(TMP . 'cache/views', 0777);
+@mkdir(TMP . 'cache/models');
+@mkdir(TMP . 'cache/persistent');
+@mkdir(TMP . 'cache/views');
 
 $cache = [
     'default' => [
@@ -101,14 +109,23 @@ Cake\Core\Configure::write('Session', [
     'defaults' => 'php',
 ]);
 
+if (!getenv('DB_URL')) {
+    putenv('DB_URL=sqlite:///:memory:');
+}
+
+ConnectionManager::setConfig('test', ['url' => getenv('DB_URL')]);
+
+$loader = new SchemaLoader();
+$loader->loadInternalFile('./tests/schema.php');
+
 //init router
-\Cake\Routing\Router::reload();
+Router::reload();
 Cake\Core\Configure::write('OAuth.path', [
     'plugin' => 'CakeDC/Users',
     'controller' => 'Users',
     'action' => 'socialLogin',
     'prefix' => null,
 ]);
-$app = new \CakeDC\Auth\Test\TestApplication(__DIR__ . DS . 'config');
+$app = new TestApplication(__DIR__ . DS . 'config');
 $app->bootstrap();
 $app->pluginBootstrap();

--- a/tests/config/bootstrap.php
+++ b/tests/config/bootstrap.php
@@ -8,12 +8,3 @@
  * @copyright Copyright 2010 - 2019, Cake Development Corporation (https://www.cakedc.com)
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-// Ensure default test connection is defined
-if (!getenv('db_dsn')) {
-    putenv('db_dsn=sqlite:///:memory:');
-}
-
-Cake\Datasource\ConnectionManager::setConfig('test', [
-    'url' => getenv('db_dsn'),
-    'timezone' => 'UTC',
-]);

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -1,97 +1,100 @@
 <?php
 
-use Cake\Routing\Router;
+use Cake\Routing\Route\DashedRoute;
+use Cake\Routing\RouteBuilder;
 
-Router::defaultRouteClass(\Cake\Routing\Route\DashedRoute::class);
+return static function (RouteBuilder $routes) {
+    $routes->setRouteClass(DashedRoute::class);
 
-Router::scope('/', function (\Cake\Routing\RouteBuilder $routes) {
-    $routes->setExtensions(['other']);
-    $routes->connect('/my-test', [
+    $routes->scope('/', function (RouteBuilder $routes) {
+        $routes->setExtensions(['other']);
+        $routes->connect('/my-test', [
         'plugin' => 'CakeDC/Users',
         'controller' => 'Users',
         'action' => 'myTest',
-    ]);
-    $routes->connect('/test-named', [
+        ]);
+        $routes->connect('/test-named', [
         'plugin' => 'CakeDC/Users',
         'controller' => 'Users',
         'action' => 'myTest',
-    ], [
+        ], [
         '_name' => 'testNamed',
-    ]);
-    $routes->connect('/tests/tests/test', [
+        ]);
+        $routes->connect('/tests/tests/test', [
         'plugin' => 'Tests',
         'controller' => 'Tests',
         'action' => 'test',
-    ]);
-    $routes->connect('/tests/tests/one', [
+        ]);
+        $routes->connect('/tests/tests/one', [
         'plugin' => 'Tests',
         'controller' => 'Tests',
         'action' => 'one',
-    ]);
-    $routes->connect('/tests/tests/three', [
+        ]);
+        $routes->connect('/tests/tests/three', [
         'plugin' => 'Tests',
         'controller' => 'Tests',
         'action' => 'three',
-    ]);
-    $routes->connect('/tests/tests/any', [
+        ]);
+        $routes->connect('/tests/tests/any', [
         'plugin' => 'Tests',
         'controller' => 'Tests',
         'action' => 'any',
-    ]);
-    $routes->connect('/tests/test-tests/test-action', [
+        ]);
+        $routes->connect('/tests/test-tests/test-action', [
         'plugin' => 'Tests',
         'controller' => 'TestTests',
         'action' => 'testAction',
-    ]);
-    $routes->connect('/tests2/test-tests/test-action', [
+        ]);
+        $routes->connect('/tests2/test-tests/test-action', [
         'plugin' => 'tests',
         'controller' => 'test-tests',
         'action' => 'test-action',
-    ]);
-    $routes->connect('/any/any/any', [
+        ]);
+        $routes->connect('/any/any/any', [
         'plugin' => 'Any',
         'controller' => 'Any',
         'action' => 'any',
-    ]);
-    $routes->connect('/any/tests/test', [
+        ]);
+        $routes->connect('/any/tests/test', [
         'plugin' => 'Any',
         'controller' => 'Tests',
         'action' => 'test',
-    ]);
-    $routes->connect('/something/something/test', [
+        ]);
+        $routes->connect('/something/something/test', [
         'plugin' => 'Something',
         'controller' => 'Something',
         'action' => 'test',
-    ]);
-    $routes->connect('/something/something/something', [
+        ]);
+        $routes->connect('/something/something/something', [
         'plugin' => 'Something',
         'controller' => 'Something',
         'action' => 'something',
-    ]);
-    $routes->connect('/csv/tests/one', [
+        ]);
+        $routes->connect('/csv/tests/one', [
         'prefix' => 'csv',
         'controller' => 'Tests',
         'action' => 'one',
-    ]);
-    $routes->connect('/ord/tests/test', [
+        ]);
+        $routes->connect('/ord/tests/test', [
         'plugin' => 'Ord',
         'controller' => 'Tests',
         'action' => 'test',
-    ]);
+        ]);
 
-    $routes->fallbacks(\Cake\Routing\Route\DashedRoute::class);
+        $routes->fallbacks(DashedRoute::class);
 
-    $routes->setExtensions(['csv']);
-    $routes->connect('/tests/one', [
+        $routes->setExtensions(['csv']);
+        $routes->connect('/tests/one', [
         'controller' => 'Tests',
         'action' => 'one',
-    ]);
-});
+        ]);
+    });
 
-Router::scope('/admin', ['prefix' => 'admin'], function (\Cake\Routing\RouteBuilder $routes) {
-    $routes->setExtensions(['other', 'csv']);
-    $routes->connect('/tests/one', [
+    $routes-> scope('/admin', ['prefix' => 'admin'], function (RouteBuilder $routes) {
+        $routes->setExtensions(['other', 'csv']);
+        $routes->connect('/tests/one', [
         'controller' => 'Tests',
         'action' => 'one',
-    ]);
-});
+        ]);
+    });
+};

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+return [
+
+  [
+    'table' => 'posts',
+    'columns' => [
+      'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+      'title' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'user_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+    ],
+    'constraints' => [
+      'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+    ],
+  ],
+
+  [
+    'table' => 'posts_users',
+    'columns' => [
+      'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+      'user_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'post_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+    ],
+    'constraints' => [
+      'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+    ],
+  ],
+
+  [
+    'table' => 'social_accounts',
+    'columns' => [
+      'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+      'user_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'provider' => ['type' => 'string', 'length' => 255, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+      'username' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'reference' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'avatar' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'description' => ['type' => 'text', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+      'token' => ['type' => 'string', 'length' => 500, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'token_secret' => ['type' => 'string', 'length' => 500, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'token_expires' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+      'active' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => true, 'comment' => '', 'precision' => null],
+      'data' => ['type' => 'text', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+      'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+      'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+    ],
+    'constraints' => [
+      'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+    ],
+  ],
+
+  [
+    'table' => 'users',
+    'columns' => [
+      'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+      'username' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'email' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'password' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'first_name' => ['type' => 'string', 'length' => 50, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'last_name' => ['type' => 'string', 'length' => 50, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'token' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'token_expires' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+      'api_token' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'activation_date' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+      'secret' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+      'secret_verified' => ['type' => 'boolean', 'length' => null, 'null' => true, 'default' => false, 'comment' => '', 'precision' => null],
+      'tos_date' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+      'active' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => true, 'comment' => '', 'precision' => null],
+      'is_superuser' => ['type' => 'boolean', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => false, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+      'role' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => 'user', 'comment' => '', 'precision' => null, 'fixed' => null],
+      'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+      'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+    ],
+    'constraints' => [
+      'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+    ],
+  ],
+
+];


### PR DESCRIPTION
This PR provides compatibility with the current Cake5 beta-1

This also of course required the following base adjustments in the composer.json
```
    "require": {
        "php": ">=8.1.0",
        "cakephp/cakephp": "5.x-dev"
    },
    "require-dev": {
        "cakephp/authorization": "3.x-dev",
        "cakephp/cakephp-codesniffer": "^5.0",
        "cakephp/authentication": "3.x-dev",
    }
```

This also updates PHPStan and Psalm to the latest versions as well as PHPUnit to 9.5

I first tried to make CakeDC/Users Cake5 compatible but saw, that this plugin needs to be updated beforehand.

Since the current main branch is `6.next-cake4` I first did all the adjustments based on that one.
Unfortunately I realized pretty late that `8.next-cake4` was present as well.

Therefore I just merged 8.next into mine and fixed all the merge conflicts afterwards.