### PR TITLE
support robthree/twofactorauth v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "league/oauth2-linkedin": "@stable",
         "luchianenco/oauth2-amazon": "^1.1",
         "google/recaptcha": "@stable",
-        "robthree/twofactorauth": "^1.6",
+        "robthree/twofactorauth": "^2.0",
         "league/oauth1-client": "^1.7",
         "cakephp/authorization": "3.x-dev",
         "cakephp/cakephp-codesniffer": "^5.0",

--- a/config/auth.php
+++ b/config/auth.php
@@ -92,7 +92,7 @@ return [
         // The number of seconds a code will be valid
         'period' => 30,
         // The algorithm used
-        'algorithm' => 'sha1',
+        'algorithm' => \RobThree\Auth\Algorithm::Sha1,
         // QR-code provider (more on this later)
         'qrcodeprovider' => null,
         // Random Number Generator provider (more on this later)


### PR DESCRIPTION
They moved to require PHP 8.1 and added an enum for all the supported algorithms instead of just specifying the algorithm as a string. Therefore this is a breaking change.