### PR TITLE
bypass DebugKit urls in default permissions

### DIFF
--- a/config/permissions.php
+++ b/config/permissions.php
@@ -120,6 +120,13 @@ $permissions = [
         'controller' => 'Pages',
         'action' => 'display',
     ],
+    [
+        'role' => '*',
+        'plugin' => 'DebugKit',
+        'controller' => '*',
+        'action' => '*',
+        'bypassAuth' => true,
+    ],
 ];
 
 $preload = \Cake\Core\Configure::read('CakeDC/Auth.preloadPermissions', []);

--- a/src/Rbac/Permissions/AbstractProvider.php
+++ b/src/Rbac/Permissions/AbstractProvider.php
@@ -114,6 +114,13 @@ abstract class AbstractProvider
                 'controller' => 'Pages',
                 'action' => 'display',
             ],
+            [
+                'role' => '*',
+                'plugin' => 'DebugKit',
+                'controller' => '*',
+                'action' => '*',
+                'bypassAuth' => true,
+            ],
         ];
     }
 

--- a/tests/TestCase/Rbac/RbacTest.php
+++ b/tests/TestCase/Rbac/RbacTest.php
@@ -105,6 +105,13 @@ class RbacTest extends TestCase
                 'controller' => 'Pages',
                 'action' => 'display',
             ],
+            [
+                'role' => '*',
+                'plugin' => 'DebugKit',
+                'controller' => '*',
+                'action' => '*',
+                'bypassAuth' => true,
+            ],
         ];
         $this->rbac = new Rbac($this->defaultPermissions);
     }


### PR DESCRIPTION
This commit fixes the issue with infinite redirect loop when app using this plugin have DebugKit enabled